### PR TITLE
minor example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Provisions 2 Windows 2016 Datacenter Server VMs using `vm_os_simple` to a new VN
     location = "East US 2"
     admin_password = ComplxP@ssw0rd!
     vm_os_simple = "WindowsServer"
-    public_ip_dns = "mywindowsservers225"
+    public_ip_dns = "mywinsrv252"
     remote_port = "3389"
     nb_instances = 2
     vnet_subnet_id = "${module.network.vnet_subnets[0]}"


### PR DESCRIPTION
Fix the Windows Server public DNS IP example name to be valid. Otherwise you get:
```
* module.mycompute.azurerm_public_ip.vm: 1 error(s) occurred:

* azurerm_public_ip.vm: network.PublicIPAddressesClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="DomainNameLabelReserved" Message="The domain name label mywindowsservers225 is invalid. The name itself or part of the name is a reserved word such as a trademark. Please use a different name." Details=[]
```