### PR TITLE
[WIP] Add boot diagnostics option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_storage_account" "vm-sa" {
   name = "${lower(replace(var.vm_hostname,"/[[:^alpha:]]/",""))}"
   resource_group_name = "${azurerm_resource_group.vm.name}"
   location = "${var.location}"
-  account_type = "${var.storage_account_type}"
+  account_type = "${var.boot_diagnostics_sa_type}"
   tags = "${var.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ resource "azurerm_public_ip" "vm" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"
-  domain_name_label            = "${var.public_ip_dns}"
+  domain_name_label            = "${var.public_ip_dns}-${count.index}"
 }
 
 resource "azurerm_network_security_group" "vm" {
@@ -151,6 +151,6 @@ resource "azurerm_network_interface" "vm" {
     subnet_id                               = "${var.vnet_subnet_id}"
     private_ip_address_allocation           = "Dynamic"
     #public_ip_address_id                    = "${count.index == 0 ? azurerm_public_ip.vm.id : ""}"
-    public_ip_address_id                    = "${var.public_ip == "true" ? azurerm_public_ip.vm.id : ""}"
+    public_ip_address_id                    = "${var.public_ip == "true" ? element(azurerm_public_ip.vm.*.id, count.index) : ""}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -150,6 +150,7 @@ resource "azurerm_network_interface" "vm" {
     name                                    = "ipconfig${count.index}"
     subnet_id                               = "${var.vnet_subnet_id}"
     private_ip_address_allocation           = "Dynamic"
-    public_ip_address_id                    = "${count.index == 0 ? azurerm_public_ip.vm.id : ""}"
+    #public_ip_address_id                    = "${count.index == 0 ? azurerm_public_ip.vm.id : ""}"
+    public_ip_address_id                    = "${var.public_ip == "true" ? azurerm_public_ip.vm.id : ""}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "azurerm_public_ip" "vm" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"
-  domain_name_label            = "${var.public_ip_dns}-${count.index + 1}"
+  domain_name_label            = "${var.vm_hostname}-${count.index + 1}"
 }
 
 resource "azurerm_network_security_group" "vm" {

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_storage_account" "vm-sa" {
 
 resource "azurerm_virtual_machine" "vm-linux" {
   count = "${contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") ? 0 : var.nb_instances}"
-  name                  = "${var.vm_hostname}${count.index}"
+  name                  = "${var.vm_hostname}-${count.index + 1}"
   location              = "${var.location}"
   resource_group_name   = "${azurerm_resource_group.vm.name}"
   availability_set_id   = "${azurerm_availability_set.vm.id}"
@@ -69,7 +69,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
 
 resource "azurerm_virtual_machine" "vm-windows" {
   count = "${contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") ? var.nb_instances : 0}"
-  name                  = "${var.vm_hostname}${count.index}"
+  name                  = "${var.vm_hostname}-${count.index + 1}"
   location              = "${var.location}"
   resource_group_name   = "${azurerm_resource_group.vm.name}"
   availability_set_id   = "${azurerm_availability_set.vm.id}"
@@ -112,7 +112,8 @@ resource "azurerm_availability_set" "vm" {
 }
 
 resource "azurerm_public_ip" "vm" {
-  name                         = "${var.vm_hostname}-publicIP"
+  count                        = "${var.public_ip == "true" ? var.nb_instances : 0}"
+  name                         = "${var.vm_hostname}-${count.index}-publicIP"
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"

--- a/main.tf
+++ b/main.tf
@@ -56,13 +56,15 @@ resource "azurerm_virtual_machine" "vm-linux" {
     managed_disk_type = "${var.storage_account_type}"
   }
 
-  storage_data_disk {
-    name = "${element(azurerm_managed_disk.vm.*.name, count.index)}"
-    managed_disk_id = "${element(azurerm_managed_disk.vm.*.id, count.index)}"
-    create_option = "Attach"
-    lun = 0
-    disk_size_gb = "${element(azurerm_managed_disk.vm.*.disk_size_gb, count.index)}"
-  }
+
+ storage_data_disk {
+   name = "${element(azurerm_managed_disk.vm.*.name, count.index)}"
+   managed_disk_id = "${element(azurerm_managed_disk.vm.*.id, count.index)}"
+   create_option = "Attach"
+   lun = 0
+   disk_size_gb = "${element(azurerm_managed_disk.vm.*.disk_size_gb, count.index)}"
+ }
+
   
   os_profile {
     computer_name  = "${var.vm_hostname}-${count.index + 1}"

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,16 @@ resource "azurerm_storage_account" "vm-sa" {
   tags = "${var.tags}"
 }
 
+resource "azurerm_managed_disk" "vm" {
+  count = "${var.nb_instances}"
+  name = "datadisk-${var.vm_hostname}-${count.index + 1}"
+  location = "${azurerm_resource_group.vm.location}"
+  resource_group_name = "${azurerm_resource_group.vm.name}"
+  storage_account_type = "${var.data_sa_type}"
+  create_option = "Empty"
+  disk_size_gb = "${var.data_disk_size_gb}"
+}
+
 resource "azurerm_virtual_machine" "vm-linux" {
   count = "${contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") ? 0 : var.nb_instances}"
   name                  = "${var.vm_hostname}-${count.index + 1}"
@@ -40,22 +50,22 @@ resource "azurerm_virtual_machine" "vm-linux" {
   }
 
   storage_os_disk {
-    name          = "osdisk${count.index}"
+    name          = "osdisk-${var.vm_hostname}-${count.index + 1}"
     create_option = "FromImage"
     caching           = "ReadWrite"
     managed_disk_type = "${var.storage_account_type}"
   }
 
   storage_data_disk {
-    name = "${azurerm_managed_disk.vm.name}"
-    managed_disk_id = "${azurerm_managed_disk.vm.id}"
+    name = "${element(azurerm_managed_disk.vm.*.name, count.index)}"
+    managed_disk_id = "${element(azurerm_managed_disk.vm.*.id, count.index)}"
     create_option = "Attach"
     lun = 0
-    disk_size_gb = "${azurerm_managed_disk.vm.disk_size_gb}"
+    disk_size_gb = "${element(azurerm_managed_disk.vm.*.disk_size_gb, count.index)}"
   }
   
   os_profile {
-    computer_name  = "${var.vm_hostname}-${count.index}"
+    computer_name  = "${var.vm_hostname}-${count.index + 1}"
     admin_username = "${var.admin_username}"
     admin_password = "${var.admin_password}"
   }
@@ -93,22 +103,22 @@ resource "azurerm_virtual_machine" "vm-windows" {
   }
 
   storage_os_disk {
-    name              = "osdisk${count.index}"
+    name              = "osdisk-${var.vm_hostname}-${count.index + 1}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     managed_disk_type = "${var.storage_account_type}"
   }
 
   storage_data_disk {
-    name = "${azurerm_managed_disk.vm.name}"
-    managed_disk_id = "${azurerm_managed_disk.vm.id}"
+    name = "${element(azurerm_managed_disk.vm.*.name, count.index)}"
+    managed_disk_id = "${element(azurerm_managed_disk.vm.*.id, count.index)}"
     create_option = "Attach"
     lun = 0
-    disk_size_gb = "${azurerm_managed_disk.vm.disk_size_gb}"
+    disk_size_gb = "${element(azurerm_managed_disk.vm.*.disk_size_gb, count.index)}"
   }
 
   os_profile {
-    computer_name  = "${var.vm_hostname}-${count.index}"
+    computer_name  = "${var.vm_hostname}-${count.index + 1}"
     admin_username = "${var.admin_username}"
     admin_password = "${var.admin_password}"
   }
@@ -117,6 +127,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
     storage_uri = "${azurerm_storage_account.vm-sa.primary_blob_endpoint}"
   }
 }
+
 
 resource "azurerm_availability_set" "vm" {
   name                         = "${var.vm_hostname}avset"
@@ -129,11 +140,11 @@ resource "azurerm_availability_set" "vm" {
 
 resource "azurerm_public_ip" "vm" {
   count                        = "${var.public_ip == "true" ? var.nb_instances : 0}"
-  name                         = "${var.vm_hostname}-${count.index}-publicIP"
+  name                         = "${var.vm_hostname}-${count.index + 1}-publicIP"
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"
-  domain_name_label            = "${var.public_ip_dns}-${count.index}"
+  domain_name_label            = "${var.public_ip_dns}-${count.index + 1}"
 }
 
 resource "azurerm_network_security_group" "vm" {
@@ -157,25 +168,17 @@ resource "azurerm_network_security_group" "vm" {
 
 resource "azurerm_network_interface" "vm" {
   count               = "${var.nb_instances}"
-  name                = "nic${count.index}"
+  name                = "nic-${var.vm_hostname}-${count.index + 1}"
   location            = "${azurerm_resource_group.vm.location}"
   resource_group_name = "${azurerm_resource_group.vm.name}"
   network_security_group_id = "${azurerm_network_security_group.vm.id}"
 
   ip_configuration {
-    name                                    = "ipconfig${count.index}"
+    name                                    = "ipconfig-${var.vm_hostname}-${count.index + 1}"
     subnet_id                               = "${var.vnet_subnet_id}"
     private_ip_address_allocation           = "Dynamic"
-    public_ip_address_id                    = "${var.public_ip == "true" ? element(azurerm_public_ip.vm.*.id, count.index) : ""}"
+    # https://github.com/hashicorp/terraform/issues/11210
+    public_ip_address_id                    = "${length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, list("")), count.index) : ""}"
   }
-}
-
-resource "azurerm_managed_disk" "vm" {
-  name = "datadisk-${var.vm_hostname}-${count.index + 1}"
-  location = "${azurerm_resource_group.vm.location}"
-  resource_group_name = "${azurerm_resource_group.vm.name}"
-  storage_account_type = "${var.data_sa_type}"
-  create_option = "Empty"
-  disk_size_gb = "${var.data_disk_size_gb}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,6 @@ resource "azurerm_virtual_machine" "vm-linux" {
 
  storage_data_disk {
    name = "${element(azurerm_managed_disk.vm.*.name, count.index)}"
-   managed_disk_id = "${element(azurerm_managed_disk.vm.*.id, count.index)}"
    create_option = "Attach"
    lun = 0
    disk_size_gb = "${element(azurerm_managed_disk.vm.*.disk_size_gb, count.index)}"
@@ -147,7 +146,7 @@ resource "azurerm_public_ip" "vm" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"
-  domain_name_label            = "${var.vm_hostname}-${count.index + 1}"
+  domain_name_label            = "${lower(var.vm_hostname)}-${count.index + 1}"
 }
 
 resource "azurerm_network_security_group" "vm" {

--- a/main.tf
+++ b/main.tf
@@ -34,12 +34,13 @@ resource "azurerm_managed_disk" "vm" {
 
 resource "azurerm_virtual_machine" "vm-linux" {
   count = "${contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") ? 0 : var.nb_instances}"
-  name                  = "${var.vm_hostname}-${count.index + 1}"
-  location              = "${var.location}"
-  resource_group_name   = "${azurerm_resource_group.vm.name}"
-  availability_set_id   = "${azurerm_availability_set.vm.id}"
-  vm_size               = "${var.vm_size}"
-  network_interface_ids = ["${element(azurerm_network_interface.vm.*.id, count.index)}"]
+  name                          = "${var.vm_hostname}-${count.index + 1}"
+  location                      = "${var.location}"
+  resource_group_name           = "${azurerm_resource_group.vm.name}"
+  availability_set_id           = "${azurerm_availability_set.vm.id}"
+  vm_size                       = "${var.vm_size}"
+  network_interface_ids         = ["${element(azurerm_network_interface.vm.*.id, count.index)}"]
+  delete_os_disk_on_termination = "${var.delete_os_disk_on_termination}"
 
   storage_image_reference {
     id        = "${var.vm_os_id}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "availability_set_id" {
   description = "id of the availability set where the vms are provisioned."
   value = "${azurerm_availability_set.vm.id}"
 }
+
+output "vm_hostname" {
+  description = "hostname of the virtual machine"
+  value = "${concat(azurerm_virtual_machine.vm-linux.*.name, azurerm_virtual_machine.vm-windows.*.name)}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -97,3 +97,8 @@ variable "public_ip_address_allocation" {
   description = "Defines how an IP address is assigned. Options are Static or Dynamic."
   default = "static"
 }
+
+variable "boot_diagnostics" {
+  description = "(Optional) Enable or Disable boot diagnostics"
+  default = "false"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,6 @@ variable "data_sa_type" {
 }
 
 variable "data_disk_size_gb" {
-  description = "Data disk size in Gb"
-  default = 1
+  description = "Storage data disk size size"
+  default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -108,4 +108,7 @@ variable "boot_diagnostics_sa_type" {
   default = "Standard_LRS"
 }
   
-  
+variable "public_ip" {
+  description = "(Optional) Add Public IP or not"
+  default = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,10 @@ variable "boot_diagnostics" {
   description = "(Optional) Enable or Disable boot diagnostics"
   default = "false"
 }
+
+variable "boot_diagnostics_sa_type" {
+  description = "(Optional) Storage account type for boot diagnostics"
+  default = "Standard_LRS"
+}
+  
+  

--- a/variables.tf
+++ b/variables.tf
@@ -122,3 +122,8 @@ variable "data_disk_size_gb" {
   description = "Storage data disk size size"
   default = ""
 }
+
+variable "delete_os_disk_on_termination" {
+  description = "Delete datadisk when machine is terminated"
+  default = "false"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,13 @@ variable "public_ip" {
   description = "(Optional) Add Public IP or not"
   default = "true"
 }
+
+variable "data_sa_type" {
+  description = "Data Disk Storage Account type"
+  default = "Standard_LRS"
+}
+
+variable "data_disk_size_gb" {
+  description = "Data disk size in Gb"
+  default = 1
+}


### PR DESCRIPTION
Allow to add boot diagnostics to an instance.
Default is false.

If you add **boot_diagnostics** to **true**, it create a storage account with the name of the instance and use it for boot diagnostics

