### PR TITLE
Fix public ip attribution for multiple instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ resource "azurerm_public_ip" "vm" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"
-  domain_name_label            = "${var.public_ip_dns}-${count.index}"
+  domain_name_label            = "${var.public_ip_dns}${count.index}"
 }
 
 resource "azurerm_network_security_group" "vm" {
@@ -136,6 +136,3 @@ resource "azurerm_network_interface" "vm" {
   }
 }
 
-
-  }
-}

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ resource "azurerm_public_ip" "vm" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"
-  domain_name_label            = "${var.public_ip_dns}"
+  domain_name_label            = "${var.public_ip_dns}-${count.index}"
 }
 
 resource "azurerm_network_security_group" "vm" {
@@ -133,5 +133,9 @@ resource "azurerm_network_interface" "vm" {
     subnet_id                               = "${var.vnet_subnet_id}"
     private_ip_address_allocation           = "Dynamic"
     public_ip_address_id                    = "${count.index == 0 ? azurerm_public_ip.vm.id : ""}"
+  }
+}
+
+
   }
 }


### PR DESCRIPTION
Add **count.index** in **domain_name_label** to avoid error when changing nb_instance var to a value higher than 1