### PR TITLE
Add space between variable name and starting {

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "location" {
   description = "The location/region where the virtual network is created. Changing this forces a new resource to be created."
 }
 
-variable "vnet_subnet_id"{
+variable "vnet_subnet_id" {
   description = "The subnet id of the virtual network where the virtual machines will reside."
 }
 
@@ -26,7 +26,7 @@ variable "ssh_key" {
   default     = "~/.ssh/id_rsa.pub"
 }
 
-variable "remote_port"{
+variable "remote_port" {
   description = "Remote tcp port to be used for access to the vms created via the nsg applied to the nics."
   default = ""
 }


### PR DESCRIPTION
Because the version of Terraform I'm using doesn't like it.