### PR TITLE
Switch Travis to build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ services:
 env:
   - TERRAFORM_VERSION=0.11.1 IMAGE_NAME=azure-compute-module
 
-before_install:
-  # Bake the image.
-  - docker build -t ${IMAGE_NAME} .
-
-script:
-  # Run the container.
-  - docker run ${IMAGE_NAME} /bin/sh -c  "rake build"
+jobs:
+  include:
+    - stage: rake build
+      install: true
+      script:
+      - docker build -t ${IMAGE_NAME} .
+      - docker run ${IMAGE_NAME} rake build


### PR DESCRIPTION
- Switches Travis to use build stages to make it consistent with all the other modules and make it easier to add `rake e2e` in its own isolated and potentially parallel flow.  IF Travis eventually supports approval workflow (like CircieCI), then this would likely be pre-requisite.
- Add in `install: true` to prevent Travis from trying to do any pre-requisite install based on Gemfile in the repo since Docker handles all of this for us.