### PR TITLE
Fix custom image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,10 +47,10 @@ resource "azurerm_virtual_machine" "vm-linux" {
 
   storage_image_reference {
     id        = "${var.vm_os_id}"
-    publisher = "${coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher)}"
-    offer     = "${coalesce(var.vm_os_offer, module.os.calculated_value_os_offer)}"
-    sku       = "${coalesce(var.vm_os_sku, module.os.calculated_value_os_sku)}"
-    version   = "${var.vm_os_version}"
+    publisher = "${var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""}"
+    offer     = "${var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""}"
+    sku       = "${var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""}"
+    version   = "${var.vm_os_id == "" ? var.vm_os_version : ""}"
   }
 
   storage_os_disk {
@@ -95,10 +95,10 @@ resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
 
   storage_image_reference {
     id        = "${var.vm_os_id}"
-    publisher = "${coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher)}"
-    offer     = "${coalesce(var.vm_os_offer, module.os.calculated_value_os_offer)}"
-    sku       = "${coalesce(var.vm_os_sku, module.os.calculated_value_os_sku)}"
-    version   = "${var.vm_os_version}"
+    publisher = "${var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""}"
+    offer     = "${var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""}"
+    sku       = "${var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""}"
+    version   = "${var.vm_os_id == "" ? var.vm_os_version : ""}"
   }
 
   storage_os_disk {
@@ -140,7 +140,7 @@ resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
 }
 
 resource "azurerm_virtual_machine" "vm-windows" {
-  count                         = "${contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") && var.data_disk == "false" ? var.nb_instances : 0}"
+  count                         = "${(contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") || (var.vm_os_id != "" && var.is_windows_image == true)) && var.data_disk == "false" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
@@ -151,10 +151,10 @@ resource "azurerm_virtual_machine" "vm-windows" {
 
   storage_image_reference {
     id        = "${var.vm_os_id}"
-    publisher = "${coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher)}"
-    offer     = "${coalesce(var.vm_os_offer, module.os.calculated_value_os_offer)}"
-    sku       = "${coalesce(var.vm_os_sku, module.os.calculated_value_os_sku)}"
-    version   = "${var.vm_os_version}"
+    publisher = "${var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""}"
+    offer     = "${var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""}"
+    sku       = "${var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""}"
+    version   = "${var.vm_os_id == "" ? var.vm_os_version : ""}"
   }
 
   storage_os_disk {
@@ -181,7 +181,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
 }
 
 resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
-  count                         = "${contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") && var.data_disk == "true" ? var.nb_instances : 0}"
+  count                         = "${(contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") || (var.vm_os_id != "" && var.is_windows_image == true)) && var.data_disk == "true" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
@@ -192,10 +192,10 @@ resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
 
   storage_image_reference {
     id        = "${var.vm_os_id}"
-    publisher = "${coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher)}"
-    offer     = "${coalesce(var.vm_os_offer, module.os.calculated_value_os_offer)}"
-    sku       = "${coalesce(var.vm_os_sku, module.os.calculated_value_os_sku)}"
-    version   = "${var.vm_os_version}"
+    publisher = "${var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""}"
+    offer     = "${var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""}"
+    sku       = "${var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""}"
+    version   = "${var.vm_os_id == "" ? var.vm_os_version : ""}"
   }
 
   storage_os_disk {

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_storage_account" "vm-sa" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux" {
-  count                         = "${!contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") && var.data_disk == "false" ? var.nb_instances : 0}"
+  count                         = "${!contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") && var.is_windows_image != "true" && var.data_disk == "false" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
@@ -84,7 +84,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
-  count                         = "${!contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") && var.data_disk == "true" ? var.nb_instances : 0}"
+  count                         = "${!contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer")  && var.is_windows_image != "true"  && var.data_disk == "true" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
@@ -140,7 +140,7 @@ resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
 }
 
 resource "azurerm_virtual_machine" "vm-windows" {
-  count                         = "${(contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") || (var.vm_os_id != "" && var.is_windows_image == true)) && var.data_disk == "false" ? var.nb_instances : 0}"
+  count                         = "${(((var.vm_os_id != "" && var.is_windows_image == "true") || contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer")) && var.data_disk == "false") ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
@@ -181,7 +181,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
 }
 
 resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
-  count                         = "${(contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer") || (var.vm_os_id != "" && var.is_windows_image == true)) && var.data_disk == "true" ? var.nb_instances : 0}"
+  count                         = "${((var.vm_os_id != "" && var.is_windows_image == "true") || contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "WindowsServer")) && var.data_disk == "true" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -61,29 +61,34 @@ variable "vm_os_simple" {
   default     = ""
 }
 
+variable "vm_os_id" {
+  description = "The resource ID of the image that you want to deploy if you are using a custom image.Note, need to provide is_windows_image = true for windows custom images."
+  default     = ""
+}
+
+variable "is_windows_image" {
+  description = "Boolean flag to notify when the custom image is windows based. Only used in conjunction with vm_os_id"
+  default     = false
+}
+
 variable "vm_os_publisher" {
-  description = "The name of the publisher of the image that you want to deploy.  Not necessary if using vm_os_simple."
+  description = "The name of the publisher of the image that you want to deploy. This is ignored when vm_os_id or vm_os_simple are provided."
   default     = ""
 }
 
 variable "vm_os_offer" {
-  description = "The name of the offer of the image that you want to deploy. Not necessary if using vm_os_simple."
+  description = "The name of the offer of the image that you want to deploy. This is ignored when vm_os_id or vm_os_simple are provided."
   default     = ""
 }
 
 variable "vm_os_sku" {
-  description = "The sku of the image that you want to deploy. Not necessary if using vm_os_simple."
+  description = "The sku of the image that you want to deploy. This is ignored when vm_os_id or vm_os_simple are provided."
   default     = ""
 }
 
 variable "vm_os_version" {
-  description = "The version of the image that you want to deploy."
+  description = "The version of the image that you want to deploy. This is ignored when vm_os_id or vm_os_simple are provided."
   default     = "latest"
-}
-
-variable "vm_os_id" {
-  description = "The ID of the image that you want to deploy if you are using a custom image."
-  default     = ""
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "vm_os_id" {
 
 variable "is_windows_image" {
   description = "Boolean flag to notify when the custom image is windows based. Only used in conjunction with vm_os_id"
-  default     = false
+  default     = "false"
 }
 
 variable "vm_os_publisher" {


### PR DESCRIPTION
Currently there is no way to create a windows VM with the existing Module using custom images. I have added one more optional variable called is_windows_image to support the windows custom image scenario. Meanwhile I also felt that we need to avoid clashing of the variables when vm_os_id is provided and the 4 variables that define the market place. I have added logic to ignore the market place image variables when user specifies vm_os_id. 