### PR TITLE
fix network module example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ Provisions an Ubuntu Server 16.04-LTS VM and a Windows 2016 Datacenter Server VM
 
   module "network" {
     source              = "Azure/network/azurerm"
+    version             = "~> 1.1.1"
     location            = "West US 2"
+    allow_rdp_traffic   = "true"
+    allow_ssh_traffic   = "true"
     resource_group_name = "terraform-compute"
   }
 
@@ -120,8 +123,11 @@ More specifically this provisions:
   }
 
   module "network" {
-    source = "Azure/network/azurerm"
-    location = "westus2"
+    source              = "Azure/network/azurerm"
+    version             = "~> 1.1.1"
+    location            = "westus2"
+    allow_rdp_traffic   = "true"
+    allow_ssh_traffic   = "true"
     resource_group_name = "terraform-advancedvms"
   }
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ Provisions an Ubuntu Server 16.04-LTS VM and a Windows 2016 Datacenter Server VM
   module "network" {
     source              = "Azure/network/azurerm"
     location            = "West US 2"
-    allow_rdp_traffic   = "true"
-    allow_ssh_traffic   = "true"
     resource_group_name = "terraform-compute"
   }
 
@@ -124,8 +122,6 @@ More specifically this provisions:
   module "network" {
     source = "Azure/network/azurerm"
     location = "westus2"
-    allow_rdp_traffic   = "true"
-    allow_ssh_traffic   = "true"
     resource_group_name = "terraform-advancedvms"
   }
 


### PR DESCRIPTION
The latest version of the network module no longer adds in nsg rules / vars, so locking to the older version of the network module until a better access solution is created. 