### PR TITLE
add vm-with-datadisk in output.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "vm_ids" {
   description = "Virtual machine ids created."
-  value       = "${concat(azurerm_virtual_machine.vm-windows.*.id, azurerm_virtual_machine.vm-linux.*.id)}"
+  value       = "${concat(azurerm_virtual_machine.vm-windows.*.id,azurerm_virtual_machine.vm-windows-with-datadisk.*.id, azurerm_virtual_machine.vm-linux.*.id,azurerm_virtual_machine.vm-linux-with-datadisk.*.id)}"
 }
 
 output "network_security_group_id" {


### PR DESCRIPTION
Hi,

I just modify output.tf. 
We are able to get **vm_ids** for _azurerm_virtual_machine.vm-\*-with-datadisk.\*.id_

Thanks.
Regards