### PR TITLE
Tag all resources ceated by the module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -236,6 +236,7 @@ resource "azurerm_availability_set" "vm" {
   platform_fault_domain_count  = 2
   platform_update_domain_count = 2
   managed                      = true
+  tags                         = "${var.tags}"
 }
 
 resource "azurerm_public_ip" "vm" {
@@ -245,6 +246,7 @@ resource "azurerm_public_ip" "vm" {
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"
   domain_name_label            = "${element(var.public_ip_dns, count.index)}"
+  tags                         = "${var.tags}"
 }
 
 resource "azurerm_network_security_group" "vm" {
@@ -264,6 +266,8 @@ resource "azurerm_network_security_group" "vm" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+
+  tags = "${var.tags}"
 }
 
 resource "azurerm_network_interface" "vm" {
@@ -279,4 +283,6 @@ resource "azurerm_network_interface" "vm" {
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = "${length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, list("")), count.index) : ""}"
   }
+
+  tags = "${var.tags}"
 }


### PR DESCRIPTION
There were several resources created by this module that were not getting tagged, this update fixes that by tagging the availability set, public ip, network security group and network interface. This should cover everything that can be tagged, but if there is anything missing, I'd be happy to update the PR. Thanks!