### PR TITLE
Provision vm agents for Windows machines

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,9 @@ resource "azurerm_virtual_machine" "vm-windows" {
 
   tags = "${var.tags}"
 
-  os_profile_windows_config {}
+  os_profile_windows_config {
+    provision_vm_agent = true
+  }
 
   boot_diagnostics {
     enabled     = "${var.boot_diagnostics}"
@@ -221,7 +223,9 @@ resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
 
   tags = "${var.tags}"
 
-  os_profile_windows_config {}
+  os_profile_windows_config {
+    provision_vm_agent = true
+  }
 
   boot_diagnostics {
     enabled     = "${var.boot_diagnostics}"


### PR DESCRIPTION
Resolve #71 by overriding the default false value for provision_vm_agent.