### PR TITLE
Resolve #39: bump azurerm provider version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 0.3"
+  version = ">= 1.1.0"
 }
 
 provider "random" {


### PR DESCRIPTION
Bumped version of provider azurerm to 1.1.0, so we can use azurerm_virtual_network_gateway and azurerm_virtual_network_gateway_connection. Closes #39.