### PR TITLE
public_ip_dns is actually a required input.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -106,7 +106,7 @@ variable "public_ip_address_allocation" {
 
 variable "nb_public_ip" {
   description = "Number of public IPs to assign corresponding to one IP per vm. Set to 0 to not assign any public IP addresses."
-  default     = "1"
+  default     = "0"
 }
 
 variable "delete_os_disk_on_termination" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,6 @@ variable "vnet_subnet_id" {
 
 variable "public_ip_dns" {
   description = "Optional globally unique per datacenter region domain name label to apply to each public ip address. e.g. thisvar.varlocation.cloudapp.azure.com where you specify only thisvar here. This is an array of names which will pair up sequentially to the number of public ips defined in var.nb_public_ip. One name or empty string is required for every public ip. If no public ip is desired, then set this to an array with a single empty string."
-  default     = [""]
 }
 
 variable "admin_password" {


### PR DESCRIPTION
In the [documentation](https://registry.terraform.io/modules/Azure/compute/azurerm/1.1.7?tab=inputs), `public_ip_dns` input is not an optional input. Instead, it should be part of required inputs.
```bash
$ terraform plan

Error: module.compute.azurerm_public_ip.vm: "domain_name_label" cannot be an empty string: ""

Error: module.compute.azurerm_public_ip.vm: only lowercase alphanumeric characters and hyphens allowed in "domain_name_label": ""
```