### PR TITLE
azurerm_public_ip resource: deprecated public_ip_address_allocation 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,19 +83,6 @@ resource "azurerm_virtual_machine" "vm-linux" {
     storage_uri = "${var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : "" }"
   }
 
-  provisioner "remote-exec" {
-    inline = [ "touch $HOME/provisioned" ]
-    connection {
-      type        = "ssh"
-      user        = "${var.admin_username}"
-      private_key = "${file("${var.ssh_private_key}")}"
-    }
-  }
-
-  provisioner "local-exec" {
-    command = "ansible-playbook -u azureuser -i '${self.public_ip},' --private-key ${var.ssh_key_private} provision.yml" 
-  }
-
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {

--- a/main.tf
+++ b/main.tf
@@ -274,6 +274,32 @@ resource "azurerm_network_security_group" "vm" {
     destination_address_prefix = "*"
   }
 
+  security_rule {
+    name                       = "allow_remote_80_in_all"
+    description                = "Allow remote protocol in from all locations"
+    priority                   = 200
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow_remote_8080_in_all"
+    description                = "Allow remote protocol in from all locations"
+    priority                   = 300
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "8080"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
   tags = "${var.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -250,7 +250,7 @@ resource "azurerm_public_ip" "vm" {
   name                         = "${var.vm_hostname}-${count.index}-publicIP"
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
-  public_ip_address_allocation = "${var.public_ip_address_allocation}"
+  allocation_method            = "${var.public_ip_address_allocation}"
   domain_name_label            = "${element(var.public_ip_dns, count.index)}"
   tags                         = "${var.tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = ">= 1.21.0"
+  version = "= 1.21.0"
 }
 
 provider "random" {

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,10 @@ resource "azurerm_virtual_machine" "vm-linux" {
     }
   }
 
+  provisioner "local-exec" {
+    command = "ansible-playbook -u azureuser -i '${self.public_ip},' --private-key ${var.ssh_key_private} provision.yml" 
+  }
+
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,6 @@ resource "azurerm_virtual_machine" "vm-linux" {
     enabled     = "${var.boot_diagnostics}"
     storage_uri = "${var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : "" }"
   }
-
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ provider "azurerm" {
 }
 
 provider "random" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 module "os" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "= 1.21.0"
+  version = "~> 1.2"
 }
 
 provider "random" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = ">= 1.1.0"
+  version = ">= 1.21.0"
 }
 
 provider "random" {

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,16 @@ resource "azurerm_virtual_machine" "vm-linux" {
     enabled     = "${var.boot_diagnostics}"
     storage_uri = "${var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : "" }"
   }
+
+  provisioner "remote-exec" {
+    inline = [ "touch $HOME/provisioned" ]
+    connection {
+      type        = "ssh"
+      user        = "${var.admin_username}"
+      private_key = ${file("${var.ssh_private_key}")}
+    }
+  }
+
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
     connection {
       type        = "ssh"
       user        = "${var.admin_username}"
-      private_key = ${file("${var.ssh_private_key}")}
+      private_key = "${file("${var.ssh_private_key}")}"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,11 @@ variable "ssh_key" {
   default     = "~/.ssh/id_rsa.pub"
 }
 
+variable "ssh_private_key" {
+  description = "Path to the private key to be used for remote-exec ssh access to the VM.  Only used with non-Windows vms and can be left as-is even if using Windows vms. If specifying a path to a certification on a Windows machine to provision a linux vm use the / in the path versus backslash. e.g. c:/home/id_rsa.pub"
+  default     = "~/.ssh/id_rsa"
+}
+
 variable "remote_port" {
   description = "Remote tcp port to be used for access to the vms created via the nsg applied to the nics."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ variable "tags" {
 
 variable "public_ip_address_allocation" {
   description = "Defines how an IP address is assigned. Options are Static or Dynamic."
-  default     = "dynamic"
+  default     = "Dynamic"
 }
 
 variable "nb_public_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,11 +26,6 @@ variable "ssh_key" {
   default     = "~/.ssh/id_rsa.pub"
 }
 
-variable "ssh_private_key" {
-  description = "Path to the private key to be used for remote-exec ssh access to the VM.  Only used with non-Windows vms and can be left as-is even if using Windows vms. If specifying a path to a certification on a Windows machine to provision a linux vm use the / in the path versus backslash. e.g. c:/home/id_rsa.pub"
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "remote_port" {
   description = "Remote tcp port to be used for access to the vms created via the nsg applied to the nics."
   default     = ""


### PR DESCRIPTION
Changed to allocation_method. Values are: Dynamic or Static. 
I also changed value in var.public_ip_address_allocation in order to use case-sensitive value (Dynamic as default) but I did not change variable name for backward compatibility. 