### PR TITLE
Fixed condition in azurerm_virtual_machine count detecting windows string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_storage_account" "vm-sa" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux" {
-  count                         = "${!contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "Windows") && var.is_windows_image != "true" && var.data_disk == "false" ? var.nb_instances : 0}"
+  count                          = "${!contains(list("${replace("${var.vm_os_simple}", "/(?:.*)((?i)windows)(?:.*)/", "windows")}", "${replace("${var.vm_os_offer}", "/(?:.*)((?i)windows)(?:.*)/", "windows")}"), "windows") && var.is_windows_image != "true" && var.data_disk == "false" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
@@ -85,7 +85,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
-  count                         = "${!contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "Windows")  && var.is_windows_image != "true"  && var.data_disk == "true" ? var.nb_instances : 0}"
+  count                          = "${!contains(list("${replace("${var.vm_os_simple}", "/(?:.*)((?i)windows)(?:.*)/", "windows")}", "${replace("${var.vm_os_offer}", "/(?:.*)((?i)windows)(?:.*)/", "windows")}"), "windows") && var.is_windows_image != "true" && var.data_disk == "true" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
@@ -142,7 +142,7 @@ resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
 }
 
 resource "azurerm_virtual_machine" "vm-windows" {
-  count                         = "${((var.is_windows_image == "true" || contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "Windows")) && var.data_disk == "false") ? var.nb_instances : 0}"
+  count                         = "${((var.is_windows_image == "true" || contains(list("${replace("${var.vm_os_simple}", "/(?:.*)((?i)windows)(?:.*)/", "windows")}", "${replace("${var.vm_os_offer}", "/(?:.*)((?i)windows)(?:.*)/", "windows")}"), "windows")) && var.data_disk == "false") ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
@@ -185,7 +185,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
 }
 
 resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
-  count                         = "${(var.is_windows_image == "true" || contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "Windows")) && var.data_disk == "true" ? var.nb_instances : 0}"
+  count                         = "${((var.is_windows_image == "true" || contains(list("${replace("${var.vm_os_simple}", "/(?:.*)((?i)windows)(?:.*)/", "windows")}", "${replace("${var.vm_os_offer}", "/(?:.*)((?i)windows)(?:.*)/", "windows")}"), "windows")) && var.data_disk == "true") ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
   location                      = "${var.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"


### PR DESCRIPTION
Original conditions setting amount of VMs to be created according to detected type of virtual machine based on variables `vm_os_simple` and `vm_os_offer` 
```
count                         = "${!contains(list("${var.vm_os_simple}","${var.vm_os_offer}"), "Windows")  && var.is_windows_image != "true"  && var.data_disk == "true" ? var.nb_instances : 0}"
```
has been comparing complete strings in list (i.e. `"Windows" == "Windows"`, but `"WindowsServer" != "Windows"`):

```
> contains(list("Windows", "Ubuntu"), "Windows")
true
> contains(list("WindowsServer", "Ubuntu"), "Windows")
false
```
I have changed conditions for `count` variable to check substrings (case insensitive), which is in my opinion "more versatile"
```
> contains(list("${replace("WindowsServer", "/(?:.*)((?i)windows)(?:.*)/", "windows")}", "${replace("Ubuntu", "/(?:.*)((?i)windows)(?:.*)/", "windows")}"), "windows")
true
> contains(list("${replace("Linux", "/(?:.*)((?i)windows)(?:.*)/", "windows")}", "${replace("Ubuntu", "/(?:.*)((?i)windows)(?:.*)/", "windows")}"), "windows")
false
```

