### PR TITLE
Move Security Group Rule to Dedicated Resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -264,18 +264,18 @@ resource "azurerm_network_security_group" "vm" {
 }
 
 resource "azurerm_network_security_rule" "vm" {
-  name                       = "allow_remote_${coalesce(var.remote_port,module.os.calculated_remote_port)}_in_all"
-  description                = "Allow remote protocol in from all locations"
-  priority                   = 100
-  direction                  = "Inbound"
-  access                     = "Allow"
-  protocol                   = "Tcp"
-  source_port_range          = "*"
-  destination_port_range     = "${coalesce(var.remote_port,module.os.calculated_remote_port)}"
-  source_address_prefix      = "*"
-  destination_address_prefix = "*"
-  resource_group_name        = "${azurerm_resource_group.vm.name}"
-  network_security_group_name= "${azurerm_network_security_group.vm.name}"
+  name                        = "allow_remote_${coalesce(var.remote_port,module.os.calculated_remote_port)}_in_all"
+  description                 = "Allow remote protocol in from all locations"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "${coalesce(var.remote_port,module.os.calculated_remote_port)}"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.vm.name}"
+  network_security_group_name = "${azurerm_network_security_group.vm.name}"
 }
 
 resource "azurerm_network_interface" "vm" {

--- a/main.tf
+++ b/main.tf
@@ -260,20 +260,22 @@ resource "azurerm_network_security_group" "vm" {
   location            = "${azurerm_resource_group.vm.location}"
   resource_group_name = "${azurerm_resource_group.vm.name}"
 
-  security_rule {
-    name                       = "allow_remote_${coalesce(var.remote_port,module.os.calculated_remote_port)}_in_all"
-    description                = "Allow remote protocol in from all locations"
-    priority                   = 100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "${coalesce(var.remote_port,module.os.calculated_remote_port)}"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
   tags = "${var.tags}"
+}
+
+resource "azurerm_network_security_rule" "vm" {
+  name                       = "allow_remote_${coalesce(var.remote_port,module.os.calculated_remote_port)}_in_all"
+  description                = "Allow remote protocol in from all locations"
+  priority                   = 100
+  direction                  = "Inbound"
+  access                     = "Allow"
+  protocol                   = "Tcp"
+  source_port_range          = "*"
+  destination_port_range     = "${coalesce(var.remote_port,module.os.calculated_remote_port)}"
+  source_address_prefix      = "*"
+  destination_address_prefix = "*"
+  resource_group_name        = "${azurerm_resource_group.vm.name}"
+  network_security_group_name= "${azurerm_network_security_group.vm.name}"
 }
 
 resource "azurerm_network_interface" "vm" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "network_security_group_id" {
   value       = "${azurerm_network_security_group.vm.id}"
 }
 
+output "network_seucrity_group_name" {
+  description = "name of the security group provisioned"
+  value       = "${azurerm_network_security_group.vm.name}"
+}
+
 output "network_interface_ids" {
   description = "ids of the vm nics provisoned."
   value       = "${azurerm_network_interface.vm.*.id}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,7 @@ output "network_security_group_id" {
   value       = "${azurerm_network_security_group.vm.id}"
 }
 
-output "network_seucrity_group_name" {
+output "network_security_group_name" {
   description = "name of the security group provisioned"
   value       = "${azurerm_network_security_group.vm.name}"
 }


### PR DESCRIPTION
### Reason For PR
This PR modifies where the security group rule is created. Before the security group rule was an inline rule in the security group resource. By using an inline rule it causes problem later if you wish to add additional rules to the security group. Basically, between terraform apply the additional rules will be added or removed. 

For convenience I also added the output `network_security_group_name` so that it can be used for additional `azurerm_network_security_rule` resources.  

### Example Usage
```
module "cluster" {
  source              = "../terraform-azurerm-compute"

  nb_instances        = "1"
  admin_username      = "${var.user_name}"
  resource_group_name = "${var.resource_group_name}"
  location            = "${var.location}"
  nb_public_ip        = "1"
  public_ip_dns       = ["test-cluster"]
  ssh_key             = "${var.public_key_path}"
}

resource "azurerm_network_security_rule" "new_rule" {
  name                       = "allow_remote_8080_in_all"
  description                = "Allow remote protocol in from all locations"
  priority                   = 101
  direction                  = "Inbound"
  access                     = "Allow"
  protocol                   = "Tcp"
  source_port_range          = "*"
  destination_port_range     = "8080"
  source_address_prefix      = "*"
  destination_address_prefix = "*"
  resource_group_name        = "${var.resource_group_name}"
  network_security_group_name= "${module.cluster.network_security_group_name}"
}
```

Any feedback and suggestions are welcome.  Thanks for the module!

#103 