### PR TITLE
Update module dependency on Random to allow use in Terraform 0.12.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ provider "azurerm" {
 }
 
 provider "random" {
-  version = "~> 1.0"
+  version = "~> 2.1"
 }
 
 module "os" {


### PR DESCRIPTION
Resolves #99, allowing use with TF 0.12.

Prior to this change, Terraform complains because of the version of the Random provider required.

```
$ terraform init
Initializing modules...
Downloading Azure/compute/azurerm 1.2.1 for VM...
- VM in .terraform/modules/VM/Azure-terraform-azurerm-compute-dbe0daa
- VM.os in .terraform/modules/VM/Azure-terraform-azurerm-compute-dbe0daa/os

Initializing the backend...

Initializing provider plugins...
- Checking for available provider plugins...

Provider "random" v1.3.1 is not compatible with Terraform 0.12.3.

Provider version 2.1.0 is the earliest compatible version. Select it with 
the following version constraint:

	version = "~> 2.1"

Terraform checked all of the plugin versions matching the given constraint:
    ~> 1.0

Consult the documentation for this provider for more information on
compatibility between provider and Terraform versions.


Error: incompatible provider version
```

Changing this requirement doesn't impact the module functionality in my testing, and allows usage on Terraform 0.12.3;

```
$ terraform init
Initializing modules...

Initializing the backend...

Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "random" (terraform-providers/random) 2.1.2...

Terraform has been successfully initialized!
```