### PR TITLE
Update the default value for `public_ip_dns`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -251,7 +251,7 @@ resource "azurerm_public_ip" "vm" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.vm.name}"
   public_ip_address_allocation = "${var.public_ip_address_allocation}"
-  domain_name_label            = "${element(var.public_ip_dns, count.index)}"
+  domain_name_label            = element(var.public_ip_dns, count.index) == "" ? null : element(var.public_ip_dns, count.index)
   tags                         = "${var.tags}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -12,8 +12,8 @@ variable "vnet_subnet_id" {
 }
 
 variable "public_ip_dns" {
-  description = "Optional globally unique per datacenter region domain name label to apply to each public ip address. e.g. thisvar.varlocation.cloudapp.azure.com where you specify only thisvar here. This is an array of names which will pair up sequentially to the number of public ips defined in var.nb_public_ip. One name or empty string is required for every public ip. If no public ip is desired, then set this to an array with a single empty string."
-  default     = [""]
+  description = "Optional globally unique per datacenter region domain name label to apply to each public ip address. e.g. thisvar.varlocation.cloudapp.azure.com where you specify only thisvar here. This is an array of names which will pair up sequentially to the number of public ips defined in var.nb_public_ip. One name is required for every public ip. If no public ip is desired, then set this to an array with a single non-empty string."
+  default     = ["empty"]
 }
 
 variable "admin_password" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,8 +12,8 @@ variable "vnet_subnet_id" {
 }
 
 variable "public_ip_dns" {
-  description = "Optional globally unique per datacenter region domain name label to apply to each public ip address. e.g. thisvar.varlocation.cloudapp.azure.com where you specify only thisvar here. This is an array of names which will pair up sequentially to the number of public ips defined in var.nb_public_ip. One name is required for every public ip. If no public ip is desired, then set this to an array with a single non-empty string."
-  default     = ["empty"]
+  description = "Optional globally unique per datacenter region domain name label to apply to each public ip address. e.g. thisvar.varlocation.cloudapp.azure.com where you specify only thisvar here. This is an array of names which will pair up sequentially to the number of public ips defined in var.nb_public_ip. One name or empty string is required for every public ip. If no public ip is desired, then set this to an array with a single empty string."
+  default     = [""]
 }
 
 variable "admin_password" {


### PR DESCRIPTION
Using Terraform 0.12.x, if the current default value "" is used for `public_ip_dns` an error will occur:

```
Error: domain_name_label must contain only lowercase alphanumeric characters, numbers and hyphens. It must start with a letter and end only with a number or letter
```

so I propose adding a check to see if the value is the empty string, and if so set `public_ip_dns = null`, otherwise to the value itself. I think this also addresses https://github.com/Azure/terraform-azurerm-compute/issues/13.

Thank you!