### PR TITLE
Change the default value of public_ip_dns

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "vnet_subnet_id" {
 
 variable "public_ip_dns" {
   description = "Optional globally unique per datacenter region domain name label to apply to each public ip address. e.g. thisvar.varlocation.cloudapp.azure.com where you specify only thisvar here. This is an array of names which will pair up sequentially to the number of public ips defined in var.nb_public_ip. One name or empty string is required for every public ip. If no public ip is desired, then set this to an array with a single empty string."
-  default     = [""]
+  default     = [null]
 }
 
 variable "admin_password" {


### PR DESCRIPTION
Using Terraform 0.12.x, if the current default value "" is used for `public_ip_dns` an error will occur:

```
Error: domain_name_label must contain only lowercase alphanumeric characters, numbers and hyphens. It must start with a letter and end only with a number or letter
```

so I propose changing the default value to `[null]` which will ensure that `domain_name_label` remains unset. I think this also addresses https://github.com/Azure/terraform-azurerm-compute/issues/13, https://github.com/Azure/terraform-azurerm-compute/issues/49.

Thank you!