### PR TITLE
Remove NSG creation for port 22, remove inline SG rule, replace 'resource_group' with data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_storage_account" "vm-sa" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux" {
-  count                         = "${! contains(list(var.vm_os_simple, var.vm_os_offer), "Windows") && var.is_windows_image != "true" && var.data_disk == "false" ? var.nb_instances : 0}"
+  count                         = ! contains(list(var.vm_os_simple, var.vm_os_offer), "Windows") && var.is_windows_image != "true" && var.data_disk == "false" ? var.nb_instances : 0
   name                          = "${var.vm_hostname}${count.index}"
   location                      = var.location
   resource_group_name           = data.azurerm_resource_group.vm.name
@@ -83,13 +83,13 @@ resource "azurerm_virtual_machine" "vm-linux" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
-  count                         = "${! contains(list(var.vm_os_simple, var.vm_os_offer), "Windows") && var.is_windows_image != "true" && var.data_disk == "true" ? var.nb_instances : 0}"
+  count                         = ! contains(list(var.vm_os_simple, var.vm_os_offer), "Windows") && var.is_windows_image != "true" && var.data_disk == "true" ? var.nb_instances : 0
   name                          = "${var.vm_hostname}${count.index}"
   location                      = var.location
   resource_group_name           = data.azurerm_resource_group.vm.name
   availability_set_id           = azurerm_availability_set.vm.id
   vm_size                       = var.vm_size
-  network_interface_ids         = element(azurerm_network_interface.vm.*.id, count.index)]
+  network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
   delete_os_disk_on_termination = var.delete_os_disk_on_termination
 
   storage_image_reference {
@@ -246,7 +246,7 @@ resource "azurerm_availability_set" "vm" {
 resource "azurerm_public_ip" "vm" {
   count               = var.nb_public_ip
   name                = "${var.vm_hostname}-${count.index}-publicIP"
-  location            = var.location}
+  location            = var.location
   resource_group_name = data.azurerm_resource_group.vm.name
   allocation_method   = var.allocation_method
   domain_name_label   = element(var.public_ip_dns, count.index)

--- a/main.tf
+++ b/main.tf
@@ -257,21 +257,7 @@ resource "azurerm_network_security_group" "vm" {
   name                = "${var.vm_hostname}-${coalesce(var.remote_port, module.os.calculated_remote_port)}-nsg"
   location            = "${data.azurerm_resource_group.vm.location}"
   resource_group_name = "${data.azurerm_resource_group.vm.name}"
-
-  security_rule {
-    name                       = "allow_remote_${coalesce(var.remote_port, module.os.calculated_remote_port)}_in_all"
-    description                = "Allow remote protocol in from all locations"
-    priority                   = 100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "${coalesce(var.remote_port, module.os.calculated_remote_port)}"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  tags = "${var.tags}"
+  tags                = "${var.tags}"
 }
 
 resource "azurerm_network_interface" "vm" {

--- a/main.tf
+++ b/main.tf
@@ -8,61 +8,61 @@ provider "random" {
 
 module "os" {
   source       = "./os"
-  vm_os_simple = "${var.vm_os_simple}"
+  vm_os_simple = var.vm_os_simple
 }
 
 data "azurerm_resource_group" "vm" {
-  name = "${var.resource_group_name}"
+  name = var.resource_group_name
 }
 
 resource "random_id" "vm-sa" {
   keepers = {
-    vm_hostname = "${var.vm_hostname}"
+    vm_hostname = var.vm_hostname
   }
 
   byte_length = 6
 }
 
 resource "azurerm_storage_account" "vm-sa" {
-  count                    = "${var.boot_diagnostics == "true" ? 1 : 0}"
+  count                    = var.boot_diagnostics == "true" ? 1 : 0
   name                     = "bootdiag${lower(random_id.vm-sa.hex)}"
-  resource_group_name      = "${data.azurerm_resource_group.vm.name}"
-  location                 = "${var.location}"
-  account_tier             = "${element(split("_", var.boot_diagnostics_sa_type), 0)}"
-  account_replication_type = "${element(split("_", var.boot_diagnostics_sa_type), 1)}"
-  tags                     = "${var.tags}"
+  resource_group_name      = data.azurerm_resource_group.vm.name
+  location                 = var.location
+  account_tier             = element(split("_", var.boot_diagnostics_sa_type), 0)
+  account_replication_type = element(split("_", var.boot_diagnostics_sa_type), 1)
+  tags                     = var.tags
 }
 
 resource "azurerm_virtual_machine" "vm-linux" {
-  count                         = "${! contains(list("${var.vm_os_simple}", "${var.vm_os_offer}"), "Windows") && var.is_windows_image != "true" && var.data_disk == "false" ? var.nb_instances : 0}"
+  count                         = "${! contains(list(var.vm_os_simple, var.vm_os_offer), "Windows") && var.is_windows_image != "true" && var.data_disk == "false" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
-  location                      = "${var.location}"
-  resource_group_name           = "${data.azurerm_resource_group.vm.name}"
-  availability_set_id           = "${azurerm_availability_set.vm.id}"
-  vm_size                       = "${var.vm_size}"
-  network_interface_ids         = ["${element(azurerm_network_interface.vm.*.id, count.index)}"]
-  delete_os_disk_on_termination = "${var.delete_os_disk_on_termination}"
+  location                      = var.location
+  resource_group_name           = data.azurerm_resource_group.vm.name
+  availability_set_id           = azurerm_availability_set.vm.id
+  vm_size                       = var.vm_size
+  network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
+  delete_os_disk_on_termination = var.delete_os_disk_on_termination
 
   storage_image_reference {
-    id        = "${var.vm_os_id}"
-    publisher = "${var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""}"
-    offer     = "${var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""}"
-    sku       = "${var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""}"
-    version   = "${var.vm_os_id == "" ? var.vm_os_version : ""}"
+    id        = var.vm_os_id
+    publisher = var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""
+    offer     = var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""
+    sku       = var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""
+    version   = var.vm_os_id == "" ? var.vm_os_version : ""
   }
 
   storage_os_disk {
     name              = "osdisk-${var.vm_hostname}-${count.index}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
-    managed_disk_type = "${var.storage_account_type}"
+    managed_disk_type = var.storage_account_type
   }
 
   os_profile {
     computer_name  = "${var.vm_hostname}${count.index}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
-    custom_data    = "${var.custom_data}"
+    admin_username = var.admin_username
+    admin_password = var.admin_password
+    custom_data    = var.custom_data
   }
 
   os_profile_linux_config {
@@ -70,56 +70,56 @@ resource "azurerm_virtual_machine" "vm-linux" {
 
     ssh_keys {
       path     = "/home/${var.admin_username}/.ssh/authorized_keys"
-      key_data = "${file("${var.ssh_key}")}"
+      key_data = file(var.ssh_key)
     }
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 
   boot_diagnostics {
-    enabled     = "${var.boot_diagnostics}"
-    storage_uri = "${var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""}"
+    enabled     = var.boot_diagnostics
+    storage_uri = var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""
   }
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
-  count                         = "${! contains(list("${var.vm_os_simple}", "${var.vm_os_offer}"), "Windows") && var.is_windows_image != "true" && var.data_disk == "true" ? var.nb_instances : 0}"
+  count                         = "${! contains(list(var.vm_os_simple, var.vm_os_offer), "Windows") && var.is_windows_image != "true" && var.data_disk == "true" ? var.nb_instances : 0}"
   name                          = "${var.vm_hostname}${count.index}"
-  location                      = "${var.location}"
-  resource_group_name           = "${data.azurerm_resource_group.vm.name}"
-  availability_set_id           = "${azurerm_availability_set.vm.id}"
-  vm_size                       = "${var.vm_size}"
-  network_interface_ids         = ["${element(azurerm_network_interface.vm.*.id, count.index)}"]
-  delete_os_disk_on_termination = "${var.delete_os_disk_on_termination}"
+  location                      = var.location
+  resource_group_name           = data.azurerm_resource_group.vm.name
+  availability_set_id           = azurerm_availability_set.vm.id
+  vm_size                       = var.vm_size
+  network_interface_ids         = element(azurerm_network_interface.vm.*.id, count.index)]
+  delete_os_disk_on_termination = var.delete_os_disk_on_termination
 
   storage_image_reference {
-    id        = "${var.vm_os_id}"
-    publisher = "${var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""}"
-    offer     = "${var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""}"
-    sku       = "${var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""}"
-    version   = "${var.vm_os_id == "" ? var.vm_os_version : ""}"
+    id        = var.vm_os_id
+    publisher = var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""
+    offer     = var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""
+    sku       = var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""
+    version   = var.vm_os_id == "" ? var.vm_os_version : ""
   }
 
   storage_os_disk {
     name              = "osdisk-${var.vm_hostname}-${count.index}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
-    managed_disk_type = "${var.storage_account_type}"
+    managed_disk_type = var.storage_account_type
   }
 
   storage_data_disk {
     name              = "datadisk-${var.vm_hostname}-${count.index}"
     create_option     = "Empty"
     lun               = 0
-    disk_size_gb      = "${var.data_disk_size_gb}"
-    managed_disk_type = "${var.data_sa_type}"
+    disk_size_gb      = var.data_disk_size_gb
+    managed_disk_type = var.data_sa_type
   }
 
   os_profile {
     computer_name  = "${var.vm_hostname}${count.index}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
-    custom_data    = "${var.custom_data}"
+    admin_username = var.admin_username
+    admin_password = var.admin_password
+    custom_data    = var.custom_data
   }
 
   os_profile_linux_config {
@@ -127,153 +127,153 @@ resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
 
     ssh_keys {
       path     = "/home/${var.admin_username}/.ssh/authorized_keys"
-      key_data = "${file("${var.ssh_key}")}"
+      key_data = file(var.ssh_key)
     }
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 
   boot_diagnostics {
-    enabled     = "${var.boot_diagnostics}"
-    storage_uri = "${var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""}"
+    enabled     = var.boot_diagnostics
+    storage_uri = var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""
   }
 }
 
 resource "azurerm_virtual_machine" "vm-windows" {
-  count                         = "${((var.is_windows_image == "true" || contains(list("${var.vm_os_simple}", "${var.vm_os_offer}"), "Windows")) && var.data_disk == "false") ? var.nb_instances : 0}"
+  count                         = ((var.is_windows_image == "true" || contains(list(var.vm_os_simple, var.vm_os_offer), "Windows")) && var.data_disk == "false") ? var.nb_instances : 0
   name                          = "${var.vm_hostname}${count.index}"
-  location                      = "${var.location}"
-  resource_group_name           = "${data.azurerm_resource_group.vm.name}"
-  availability_set_id           = "${azurerm_availability_set.vm.id}"
-  vm_size                       = "${var.vm_size}"
-  network_interface_ids         = ["${element(azurerm_network_interface.vm.*.id, count.index)}"]
-  delete_os_disk_on_termination = "${var.delete_os_disk_on_termination}"
+  location                      = var.location
+  resource_group_name           = data.azurerm_resource_group.vm.name
+  availability_set_id           = azurerm_availability_set.vm.id
+  vm_size                       = var.vm_size
+  network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
+  delete_os_disk_on_termination = var.delete_os_disk_on_termination
 
   storage_image_reference {
-    id        = "${var.vm_os_id}"
-    publisher = "${var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""}"
-    offer     = "${var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""}"
-    sku       = "${var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""}"
-    version   = "${var.vm_os_id == "" ? var.vm_os_version : ""}"
+    id        = var.vm_os_id
+    publisher = var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""
+    offer     = var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""
+    sku       = var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""
+    version   = var.vm_os_id == "" ? var.vm_os_version : ""
   }
 
   storage_os_disk {
     name              = "osdisk-${var.vm_hostname}-${count.index}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
-    managed_disk_type = "${var.storage_account_type}"
+    managed_disk_type = var.storage_account_type
   }
 
   os_profile {
     computer_name  = "${var.vm_hostname}${count.index}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
+    admin_username = var.admin_username
+    admin_password = var.admin_password
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 
   os_profile_windows_config {
     provision_vm_agent = true
   }
 
   boot_diagnostics {
-    enabled     = "${var.boot_diagnostics}"
-    storage_uri = "${var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""}"
+    enabled     = var.boot_diagnostics
+    storage_uri = var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""
   }
 }
 
 resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
-  count                         = "${(var.is_windows_image == "true" || contains(list("${var.vm_os_simple}", "${var.vm_os_offer}"), "Windows")) && var.data_disk == "true" ? var.nb_instances : 0}"
+  count                         = (var.is_windows_image == "true" || contains(list(var.vm_os_simple, var.vm_os_offer), "Windows")) && var.data_disk == "true" ? var.nb_instances : 0
   name                          = "${var.vm_hostname}${count.index}"
-  location                      = "${var.location}"
-  resource_group_name           = "${data.azurerm_resource_group.vm.name}"
-  availability_set_id           = "${azurerm_availability_set.vm.id}"
-  vm_size                       = "${var.vm_size}"
-  network_interface_ids         = ["${element(azurerm_network_interface.vm.*.id, count.index)}"]
-  delete_os_disk_on_termination = "${var.delete_os_disk_on_termination}"
+  location                      = var.location
+  resource_group_name           = data.azurerm_resource_group.vm.name
+  availability_set_id           = azurerm_availability_set.vm.id
+  vm_size                       = var.vm_size
+  network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
+  delete_os_disk_on_termination = var.delete_os_disk_on_termination
 
   storage_image_reference {
-    id        = "${var.vm_os_id}"
-    publisher = "${var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""}"
-    offer     = "${var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""}"
-    sku       = "${var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""}"
-    version   = "${var.vm_os_id == "" ? var.vm_os_version : ""}"
+    id        = var.vm_os_id
+    publisher = var.vm_os_id == "" ? coalesce(var.vm_os_publisher, module.os.calculated_value_os_publisher) : ""
+    offer     = var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""
+    sku       = var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""
+    version   = var.vm_os_id == "" ? var.vm_os_version : ""
   }
 
   storage_os_disk {
     name              = "osdisk-${var.vm_hostname}-${count.index}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
-    managed_disk_type = "${var.storage_account_type}"
+    managed_disk_type = var.storage_account_type
   }
 
   storage_data_disk {
     name              = "datadisk-${var.vm_hostname}-${count.index}"
     create_option     = "Empty"
     lun               = 0
-    disk_size_gb      = "${var.data_disk_size_gb}"
-    managed_disk_type = "${var.data_sa_type}"
+    disk_size_gb      = var.data_disk_size_gb
+    managed_disk_type = var.data_sa_type
   }
 
   os_profile {
     computer_name  = "${var.vm_hostname}${count.index}"
-    admin_username = "${var.admin_username}"
-    admin_password = "${var.admin_password}"
+    admin_username = var.admin_username
+    admin_password = var.admin_password
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 
   os_profile_windows_config {
     provision_vm_agent = true
   }
 
   boot_diagnostics {
-    enabled     = "${var.boot_diagnostics}"
-    storage_uri = "${var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""}"
+    enabled     = var.boot_diagnostics
+    storage_uri = var.boot_diagnostics == "true" ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""
   }
 }
 
 resource "azurerm_availability_set" "vm" {
   name                         = "${var.vm_hostname}-avset"
-  location                     = "${data.azurerm_resource_group.vm.location}"
-  resource_group_name          = "${data.azurerm_resource_group.vm.name}"
+  location                     = data.azurerm_resource_group.vm.location
+  resource_group_name          = data.azurerm_resource_group.vm.name
   platform_fault_domain_count  = 2
   platform_update_domain_count = 2
   managed                      = true
-  tags                         = "${var.tags}"
+  tags                         = var.tags
 }
 
 resource "azurerm_public_ip" "vm" {
-  count               = "${var.nb_public_ip}"
+  count               = var.nb_public_ip
   name                = "${var.vm_hostname}-${count.index}-publicIP"
-  location            = "${var.location}"
-  resource_group_name = "${data.azurerm_resource_group.vm.name}"
-  allocation_method   = "${var.allocation_method}"
-  domain_name_label   = "${element(var.public_ip_dns, count.index)}"
-  tags                = "${var.tags}"
+  location            = var.location}
+  resource_group_name = data.azurerm_resource_group.vm.name
+  allocation_method   = var.allocation_method
+  domain_name_label   = element(var.public_ip_dns, count.index)
+  tags                = var.tags
 }
 
 resource "azurerm_network_security_group" "vm" {
   name                = "${var.vm_hostname}-${coalesce(var.remote_port, module.os.calculated_remote_port)}-nsg"
-  location            = "${data.azurerm_resource_group.vm.location}"
-  resource_group_name = "${data.azurerm_resource_group.vm.name}"
-  tags                = "${var.tags}"
+  location            = data.azurerm_resource_group.vm.location
+  resource_group_name = data.azurerm_resource_group.vm.name
+  tags                = var.tags
 }
 
 resource "azurerm_network_interface" "vm" {
-  count                         = "${var.nb_instances}"
+  count                         = var.nb_instances
   name                          = "nic-${var.vm_hostname}-${count.index}"
-  location                      = "${data.azurerm_resource_group.vm.location}"
-  resource_group_name           = "${data.azurerm_resource_group.vm.name}"
-  network_security_group_id     = "${azurerm_network_security_group.vm.id}"
-  enable_accelerated_networking = "${var.enable_accelerated_networking}"
+  location                      = data.azurerm_resource_group.vm.location
+  resource_group_name           = data.azurerm_resource_group.vm.name
+  network_security_group_id     = azurerm_network_security_group.vm.id
+  enable_accelerated_networking = var.enable_accelerated_networking
 
   ip_configuration {
     name                          = "ipconfig${count.index}"
-    subnet_id                     = "${var.vnet_subnet_id}"
+    subnet_id                     = var.vnet_subnet_id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, list("")), count.index) : ""}"
+    public_ip_address_id          = length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, list("")), count.index) : ""
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -244,13 +244,13 @@ resource "azurerm_availability_set" "vm" {
 }
 
 resource "azurerm_public_ip" "vm" {
-  count                        = "${var.nb_public_ip}"
-  name                         = "${var.vm_hostname}-${count.index}-publicIP"
-  location                     = "${var.location}"
-  resource_group_name          = "${data.azurerm_resource_group.vm.name}"
-  public_ip_address_allocation = "${var.public_ip_address_allocation}"
-  domain_name_label            = "${element(var.public_ip_dns, count.index)}"
-  tags                         = "${var.tags}"
+  count               = "${var.nb_public_ip}"
+  name                = "${var.vm_hostname}-${count.index}-publicIP"
+  location            = "${var.location}"
+  resource_group_name = "${data.azurerm_resource_group.vm.name}"
+  allocation_method   = "${var.allocation_method}"
+  domain_name_label   = "${element(var.public_ip_dns, count.index)}"
+  tags                = "${var.tags}"
 }
 
 resource "azurerm_network_security_group" "vm" {

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.vm_tags)
 
   boot_diagnostics {
     enabled     = var.boot_diagnostics
@@ -131,7 +131,7 @@ resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.vm_tags)
 
   boot_diagnostics {
     enabled     = var.boot_diagnostics
@@ -170,7 +170,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
     admin_password = var.admin_password
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.vm_tags)
 
   os_profile_windows_config {
     provision_vm_agent = true
@@ -221,7 +221,7 @@ resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
     admin_password = var.admin_password
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.vm_tags)
 
   os_profile_windows_config {
     provision_vm_agent = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,16 @@
 output "vm_ids" {
   description = "Virtual machine ids created."
-  value       = "${concat(azurerm_virtual_machine.vm-windows.*.id,azurerm_virtual_machine.vm-windows-with-datadisk.*.id, azurerm_virtual_machine.vm-linux.*.id,azurerm_virtual_machine.vm-linux-with-datadisk.*.id)}"
+  value       = "${concat(azurerm_virtual_machine.vm-windows.*.id, azurerm_virtual_machine.vm-windows-with-datadisk.*.id, azurerm_virtual_machine.vm-linux.*.id, azurerm_virtual_machine.vm-linux-with-datadisk.*.id)}"
 }
 
 output "network_security_group_id" {
   description = "id of the security group provisioned"
   value       = "${azurerm_network_security_group.vm.id}"
+}
+
+output "network_security_group_name" {
+  description = "name of the security group provisioned"
+  value       = "${azurerm_network_security_group.vm.name}"
 }
 
 output "network_interface_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ variable "tags" {
 
 variable "allocation_method" {
   description = "Defines how an IP address is assigned. Options are Static or Dynamic."
-  default     = "dynamic"
+  default     = "Dynamic"
 }
 
 variable "nb_public_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,7 @@ variable "vm_os_version" {
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(any)
   description = "A map of the tags to use on the resources that are deployed with this module."
 
   default = {
@@ -131,7 +131,7 @@ variable "data_disk_size_gb" {
 }
 
 variable "data_disk" {
-  type        = "string"
+  type        = string
   description = "Set to true to add a datadisk."
   default     = "false"
 }
@@ -147,7 +147,7 @@ variable "boot_diagnostics_sa_type" {
 }
 
 variable "enable_accelerated_networking" {
-  type        = "string"
+  type        = string
   description = "(Optional) Enable accelerated networking on Network interface"
   default     = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,7 @@ variable "tags" {
   }
 }
 
-variable "public_ip_address_allocation" {
+variable "allocation_method" {
   description = "Defines how an IP address is assigned. Options are Static or Dynamic."
   default     = "dynamic"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,12 @@ variable "tags" {
   }
 }
 
+variable "vm_tags" {
+  type        = map(string)
+  description = "A map of custom tags to be applied on VMs."
+  default     = {}
+}
+
 variable "allocation_method" {
   description = "Defines how an IP address is assigned. Options are Static or Dynamic."
   default     = "Dynamic"


### PR DESCRIPTION
Hi, some time ago I made fork of this repo and modified module for my own needs, but as I can see there are few issues open and my PR can close them.

List of changes:
* At this moment, when module will be removed, it will try to remove whole resource group. It should use data source instead - #60 
* Port 22 shouldn't be publicly open by default - #103 
* Inline security group rule has been removed, it should be used as separate resource - #105 
* Replace `public_ip_address_allocation` with `allocation_method` in **azurerm_public_ip**
* Add `network_security_group_name` to output
* Few small formatting changes