### PR TITLE
Fix CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 env:
-  - TERRAFORM_VERSION=0.12.10 IMAGE_NAME=azure-compute-module
+  - TERRAFORM_VERSION=0.12.20 IMAGE_NAME=azure-compute-module
 
 jobs:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull the base image with given version.
-ARG BUILD_TERRAFORM_VERSION="0.12.10"
+ARG BUILD_TERRAFORM_VERSION="0.12.20"
 FROM mcr.microsoft.com/terraform-test:${BUILD_TERRAFORM_VERSION}
 
 ARG MODULE_NAME="terraform-azurerm-compute"
@@ -33,6 +33,5 @@ RUN ssh-keygen -q -t rsa -b 4096 -f $HOME/.ssh/id_rsa
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
 RUN /bin/bash -c "curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh"
-RUN terraform init
 
 RUN ["bundle", "install", "--gemfile", "./Gemfile"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-ruby "~> 2.3.0"
-
 source 'https://rubygems.org/'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org/'
 
 group :test do
   git 'https://github.com/Azure/terramodtest.git' do
-    gem 'terramodtest', :tag => 'v0.3.0'
+    gem 'terramodtest', tag: '0.5.0'
   end
 end

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ More specifically this provisions:
 - "enable_ssh_key" Enable ssh key authentication in Linux virtual Machine
 
 ```hcl
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
@@ -107,7 +111,7 @@ module "linuxservers" {
   nb_instances                  = 2
   vm_os_publisher               = "Canonical"
   vm_os_offer                   = "UbuntuServer"
-  vm_os_sku                     = "14.04.2-LTS"
+  vm_os_sku                     = "18.04-LTS"
   vnet_subnet_id                = module.network.vnet_subnets[0]
   boot_diagnostics              = true
   delete_os_disk_on_termination = true
@@ -115,6 +119,7 @@ module "linuxservers" {
   data_disk_size_gb             = 64
   data_sa_type                  = "Premium_LRS"
   enable_ssh_key                = true
+  vm_size                       = "Standard_D4s_v3"
 
   tags = {
     environment = "dev"
@@ -128,6 +133,7 @@ module "windowsservers" {
   source                        = "Azure/compute/azurerm"
   resource_group_name           = azurerm_resource_group.example.name
   vm_hostname                   = "mywinvm"
+  is_windows_image              = true
   admin_password                = "ComplxP@ssw0rd!"
   public_ip_dns                 = ["winterravmip", "winterravmip1"]
   nb_public_ip                  = 2
@@ -137,15 +143,15 @@ module "windowsservers" {
   vm_os_offer                   = "WindowsServer"
   vm_os_sku                     = "2012-R2-Datacenter"
   vm_size                       = "Standard_DS2_V2"
-  vnet_subnet_id                = module.network.vnet_subnets[1]
+  vnet_subnet_id                = module.network.vnet_subnets[0]
   enable_accelerated_networking = true
 }
 
 module "network" {
   source              = "Azure/network/azurerm"
-  version             = "3.0.0"
+  version             = "3.0.1"
   resource_group_name = azurerm_resource_group.example.name
-  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24"]
+  subnet_prefixes     = ["10.0.1.0/24"]
 
 }
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,6 @@ module "network" {
   source              = "Azure/network/azurerm"
   version             = "3.0.0"
   resource_group_name = azurerm_resource_group.example.name
-  allow_rdp_traffic   = true
-  allow_ssh_traffic   = true
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24"]
 
 }

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   }
 
   os_profile {
-    computer_name  = "myLinux"
+    computer_name  = "${var.vm_hostname}-${count.index}"
     admin_username = var.admin_username
     admin_password = var.admin_password
     custom_data    = var.custom_data
@@ -125,7 +125,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   }
 
   os_profile {
-    computer_name  = "myWindows"
+    computer_name  = "${var.vm_hostname}-${count.index}"
     admin_username = var.admin_username
     admin_password = var.admin_password
   }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_subnet" "subnet3" {
 
 module "ubuntuservers" {
   source                        = "../../"
-  vm_hostname                   = "${random_id.ip_dns.hex}-ubuntu"
+  vm_hostname                   = "${random_id.ip_dns.hex}-u"
   resource_group_name           = azurerm_resource_group.test.name
   admin_username                = var.admin_username
   admin_password                = var.admin_password
@@ -57,7 +57,7 @@ module "ubuntuservers" {
 
 module "debianservers" {
   source              = "../../"
-  vm_hostname         = "${random_id.ip_dns.hex}-debian"
+  vm_hostname         = "${random_id.ip_dns.hex}-d"
   resource_group_name = azurerm_resource_group.test.name
   admin_username      = var.admin_username
   admin_password      = var.admin_password
@@ -71,7 +71,7 @@ module "debianservers" {
 
 module "windowsservers" {
   source              = "../../"
-  vm_hostname         = "${random_id.ip_dns.hex}-windows" // line can be removed if only one VM module per resource group
+  vm_hostname         = "${random_id.ip_dns.hex}-w" // line can be removed if only one VM module per resource group
   resource_group_name = azurerm_resource_group.test.name
   is_windows_image    = true
   admin_username      = var.admin_username

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -3,7 +3,7 @@ provider "azurerm" {
 }
 
 resource "random_id" "ip_dns" {
-  byte_length = 8
+  byte_length = 4
 }
 
 resource "azurerm_resource_group" "test" {
@@ -41,7 +41,7 @@ resource "azurerm_subnet" "subnet3" {
 
 module "ubuntuservers" {
   source                        = "../../"
-  vm_hostname                   = "host${random_id.ip_dns.hex}-ubuntu"
+  vm_hostname                   = "${random_id.ip_dns.hex}-ubuntu"
   resource_group_name           = azurerm_resource_group.test.name
   admin_username                = var.admin_username
   admin_password                = var.admin_password
@@ -57,7 +57,7 @@ module "ubuntuservers" {
 
 module "debianservers" {
   source              = "../../"
-  vm_hostname         = "host${random_id.ip_dns.hex}-debian"
+  vm_hostname         = "${random_id.ip_dns.hex}-debian"
   resource_group_name = azurerm_resource_group.test.name
   admin_username      = var.admin_username
   admin_password      = var.admin_password
@@ -71,7 +71,7 @@ module "debianservers" {
 
 module "windowsservers" {
   source              = "../../"
-  vm_hostname         = "host${random_id.ip_dns.hex}-windows" // line can be removed if only one VM module per resource group
+  vm_hostname         = "${random_id.ip_dns.hex}-windows" // line can be removed if only one VM module per resource group
   resource_group_name = azurerm_resource_group.test.name
   is_windows_image    = true
   admin_username      = var.admin_username


### PR DESCRIPTION
CI test has failed for the computer_name is too long, which is created from "${var.hostname}-${count.index}". Here I shorten the hostname in fixture test. 