### PR TITLE
Fixed domain_name_label must contain only lowercase alphanumeric characters, numbers and hyphens

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "vnet_subnet_id" {
 
 variable "public_ip_dns" {
   description = "Optional globally unique per datacenter region domain name label to apply to each public ip address. e.g. thisvar.varlocation.cloudapp.azure.com where you specify only thisvar here. This is an array of names which will pair up sequentially to the number of public ips defined in var.nb_public_ip. One name or empty string is required for every public ip. If no public ip is desired, then set this to an array with a single empty string."
-  default     = [""]
+  default     = [null]
 }
 
 variable "admin_password" {


### PR DESCRIPTION
set public_ip_dns default variable to null