### PR TITLE
Conditionally create nsg security rule | Parametrise source IP ranges

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,6 +171,7 @@ resource "azurerm_network_security_group" "vm" {
 }
 
 resource "azurerm_network_security_rule" "vm" {
+  count                       = var.remote_port != "" ? 1 : 0
   name                        = "allow_remote_${coalesce(var.remote_port, module.os.calculated_remote_port)}_in_all"
   resource_group_name         = data.azurerm_resource_group.vm.name
   description                 = "Allow remote protocol in from all locations"
@@ -180,7 +181,7 @@ resource "azurerm_network_security_rule" "vm" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = coalesce(var.remote_port, module.os.calculated_remote_port)
-  source_address_prefix       = "*"
+  source_address_prefixes     = var.source_address_prefixes
   destination_address_prefix  = "*"
   network_security_group_name = azurerm_network_security_group.vm.name
 }

--- a/main.tf
+++ b/main.tf
@@ -175,7 +175,7 @@ resource "azurerm_network_security_rule" "vm" {
   name                        = "allow_remote_${coalesce(var.remote_port, module.os.calculated_remote_port)}_in_all"
   resource_group_name         = data.azurerm_resource_group.vm.name
   description                 = "Allow remote protocol in from all locations"
-  priority                    = 100
+  priority                    = 101
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -154,3 +154,8 @@ variable "nb_data_disk" {
   description = "(Optional) Number of the data disks attached to each virtual machine"
   default     = 0
 }
+
+variable "source_address_prefixes" {
+  description = "(Optional) List of source address prefixes allowed to access var.remote_port"
+  default     = ["0.0.0.0/0"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,6 @@ variable "nb_data_disk" {
 }
 
 variable "source_address_prefixes" {
-  description = "(Optional) List of source address prefixes allowed to access var.remote_port"
-  default     = ["0.0.0.0/0"]
+  description = "(Optional) List of source address prefixes allowed to access var.remote_port."
+  default     = ["*"]
 }


### PR DESCRIPTION
I would want some control on nsg security rule for remote_port:

- Create it only if remote_port is specified

- Add ability to control source IP ranges