### PR TITLE
`public_ip_address` will be empty when `allocation_method` is `Dynamic`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,6 +198,14 @@ resource "azurerm_public_ip" "vm" {
   tags                = var.tags
 }
 
+// Dynamic public ip address will be got after it's assigned to a vm
+data "azurerm_public_ip" "vm" {
+  count               = var.nb_public_ip
+  name                = azurerm_public_ip.vm[count.index].name
+  resource_group_name = data.azurerm_resource_group.vm.name
+  depends_on          = [azurerm_virtual_machine.vm-linux, azurerm_virtual_machine.vm-windows]
+}
+
 resource "azurerm_network_security_group" "vm" {
   name                = "${var.vm_hostname}-nsg"
   resource_group_name = data.azurerm_resource_group.vm.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "public_ip_id" {
 
 output "public_ip_address" {
   description = "The actual ip address allocated for the resource."
-  value       = azurerm_public_ip.vm.*.ip_address
+  value       = data.azurerm_public_ip.vm.*.ip_address
 }
 
 output "public_ip_dns_name" {


### PR DESCRIPTION
Fix https://github.com/azure/terraform-azurerm-compute/issues/149

--- PASS: TestTerraformSshExample (491.69s)
PASS