### PR TITLE
Support to change fault domain and update domain on Availability Set …

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ The variable accepts a list of maps with the following keys:
 * certificate_url : The certificate  URL in Key Vault
 * certificate_store : The certificate store on the Virtual Machine where the certificate should be added to (Windows Only).
 
+5 - You can override default (2) values of "Update Domain" and "Fault Domain" in "Availability Set" using `as_update_domain` and `as_fault_domain` variables. Changing this forces a new resource to be created.
+
 In the below example we use the data sources `azurerm_key_vault` and `azurerm_key_vault_certificate` to fetch the certificate information from Key Vault and add it to `windowsservers` via `os_profile_secrets` parameter.
 
 ```hcl
@@ -201,6 +203,8 @@ module "linuxservers" {
   ssh_key_values                   = ["ssh-rsa AAAAB3NzaC1yc2EAAAAD..."]
   vm_size                          = "Standard_D4s_v3"
   delete_data_disks_on_termination = true
+  as_update_domain                 = 3
+  as_fault_domain                  = 3
 
   tags = {
     environment = "dev"
@@ -230,6 +234,8 @@ module "windowsservers" {
   enable_accelerated_networking = true
   license_type                  = "Windows_Client"
   identity_type                 = "SystemAssigned" // can be empty, SystemAssigned or UserAssigned
+  as_update_domain              = 3
+  as_fault_domain               = 3
 
   extra_disks = [
     {

--- a/main.tf
+++ b/main.tf
@@ -235,8 +235,8 @@ resource "azurerm_availability_set" "vm" {
   name                         = "${var.vm_hostname}-avset"
   resource_group_name          = data.azurerm_resource_group.vm.name
   location                     = coalesce(var.location, data.azurerm_resource_group.vm.location)
-  platform_fault_domain_count  = 2
-  platform_update_domain_count = 2
+  platform_fault_domain_count  = var.as_fault_domain
+  platform_update_domain_count = var.as_update_domain
   managed                      = true
   tags                         = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -240,3 +240,15 @@ variable "os_profile_secrets" {
   type        = list(map(string))
   default     = []
 }
+
+variable "as_fault_domain" {
+  description = "(Optional) Number of fault domain zones in availability set. Default 2"
+  type        = number
+  default     = 2
+}
+
+variable "as_update_domain" {
+  description = "(Optional) Number of update domain zones in availability set. Default 2"
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
…(as an option)

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-compute .
$ docker run --rm azure-compute /bin/bash -c "bundle install && rake full"
```

Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:
Availability Set option settings variables


