### PR TITLE
Fixed deprecated list method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull the base image with given version.
-ARG BUILD_TERRAFORM_VERSION="0.13.5"
+ARG BUILD_TERRAFORM_VERSION="0.14.4"
 FROM mcr.microsoft.com/terraform-test:${BUILD_TERRAFORM_VERSION}
 
 ARG MODULE_NAME="terraform-azurerm-compute"

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_storage_account" "vm-sa" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux" {
-  count                         = ! contains(list(var.vm_os_simple, var.vm_os_offer), "WindowsServer") && ! var.is_windows_image ? var.nb_instances : 0
+  count                         = ! contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer") && ! var.is_windows_image ? var.nb_instances : 0
   name                          = "${var.vm_hostname}-vmLinux-${count.index}"
   resource_group_name           = data.azurerm_resource_group.vm.name
   location                      = coalesce(var.location, data.azurerm_resource_group.vm.location)
@@ -139,7 +139,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
 }
 
 resource "azurerm_virtual_machine" "vm-windows" {
-  count                         = (var.is_windows_image || contains(list(var.vm_os_simple, var.vm_os_offer), "WindowsServer")) ? var.nb_instances : 0
+  count                         = (var.is_windows_image || contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer")) ? var.nb_instances : 0
   name                          = "${var.vm_hostname}-vmWindows-${count.index}"
   resource_group_name           = data.azurerm_resource_group.vm.name
   location                      = coalesce(var.location, data.azurerm_resource_group.vm.location)
@@ -295,7 +295,7 @@ resource "azurerm_network_interface" "vm" {
     name                          = "${var.vm_hostname}-ip-${count.index}"
     subnet_id                     = var.vnet_subnet_id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, list("")), count.index) : ""
+    public_ip_address_id          = length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, tolist([""])), count.index) : ""
   }
 
   tags = var.tags


### PR DESCRIPTION
In terraform >= 0.15.0, the deprecated list method is removed. This causes the module to stop working on newer versions. List method has been changed to tolist method.

For more information see:
- https://www.terraform.io/docs/language/functions/tolist.html
- https://github.com/hashicorp/terraform/blob/v0.15/CHANGELOG.md#0150-april-14-2021

Error:

```bash
│ Error: Error in function call
│ 
│   on .terraform/modules/vm_set/main.tf line 33, in resource "azurerm_virtual_machine" "vm-linux":
│   33:   count                         = ! contains(list(var.vm_os_simple, var.vm_os_offer), "WindowsServer") && ! var.is_windows_image ? var.nb_instances : 0
│     ├────────────────
│     │ var.vm_os_offer is a string, known only after apply
│     │ var.vm_os_simple is a string, known only after apply
│ 
│ Call to function "list" failed: the "list" function was deprecated in
│ Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to
│ write a literal list.
```

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-compute .
$ docker run --rm azure-compute /bin/bash -c "bundle install && rake full"
```

Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Changes proposed in the pull request:

- Delete deprecated `list` method and replace it with `tolist`.
