### PR TITLE
Enable os_disk_size to be set, default 30GB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
     create_option     = "FromImage"
     caching           = "ReadWrite"
     managed_disk_type = var.storage_account_type
+    disk_size_gb      = var.os_disk_size_gb
   }
 
   dynamic storage_data_disk {
@@ -178,6 +179,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
     create_option     = "FromImage"
     caching           = "ReadWrite"
     managed_disk_type = var.storage_account_type
+    disk_size_gb      = var.os_disk_size_gb
   }
 
   dynamic storage_data_disk {

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_storage_account" "vm-sa" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux" {
-  count                            = ! contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer") && ! var.is_windows_image ? var.nb_instances : 0
+  count                            = !contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer") && !var.is_windows_image ? var.nb_instances : 0
   name                             = "${var.vm_hostname}-vmLinux-${count.index}"
   resource_group_name              = data.azurerm_resource_group.vm.name
   location                         = coalesce(var.location, data.azurerm_resource_group.vm.location)
@@ -40,14 +40,14 @@ resource "azurerm_virtual_machine" "vm-linux" {
   delete_os_disk_on_termination    = var.delete_os_disk_on_termination
   delete_data_disks_on_termination = var.delete_data_disks_on_termination
 
-  dynamic identity {
+  dynamic "identity" {
     for_each = length(var.identity_ids) == 0 && var.identity_type == "SystemAssigned" ? [var.identity_type] : []
     content {
       type = var.identity_type
     }
   }
 
-  dynamic identity {
+  dynamic "identity" {
     for_each = length(var.identity_ids) > 0 || var.identity_type == "UserAssigned" ? [var.identity_type] : []
     content {
       type         = var.identity_type
@@ -71,7 +71,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
     disk_size_gb      = var.os_disk_size_gb
   }
 
-  dynamic storage_data_disk {
+  dynamic "storage_data_disk" {
     for_each = range(var.nb_data_disk)
     content {
       name              = "${var.vm_hostname}-datadisk-${count.index}-${storage_data_disk.value}"
@@ -82,7 +82,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
     }
   }
 
-  dynamic storage_data_disk {
+  dynamic "storage_data_disk" {
     for_each = var.extra_disks
     content {
       name              = "${var.vm_hostname}-extradisk-${count.index}-${storage_data_disk.value.name}"
@@ -103,7 +103,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   os_profile_linux_config {
     disable_password_authentication = var.enable_ssh_key
 
-    dynamic ssh_keys {
+    dynamic "ssh_keys" {
       for_each = var.enable_ssh_key ? local.ssh_keys : []
       content {
         path     = "/home/${var.admin_username}/.ssh/authorized_keys"
@@ -111,7 +111,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
       }
     }
 
-    dynamic ssh_keys {
+    dynamic "ssh_keys" {
       for_each = var.enable_ssh_key ? var.ssh_key_values : []
       content {
         path     = "/home/${var.admin_username}/.ssh/authorized_keys"
@@ -151,14 +151,14 @@ resource "azurerm_virtual_machine" "vm-windows" {
   delete_os_disk_on_termination = var.delete_os_disk_on_termination
   license_type                  = var.license_type
 
-  dynamic identity {
+  dynamic "identity" {
     for_each = length(var.identity_ids) == 0 && var.identity_type == "SystemAssigned" ? [var.identity_type] : []
     content {
       type = var.identity_type
     }
   }
 
-  dynamic identity {
+  dynamic "identity" {
     for_each = length(var.identity_ids) > 0 || var.identity_type == "UserAssigned" ? [var.identity_type] : []
     content {
       type         = var.identity_type
@@ -182,7 +182,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
     disk_size_gb      = var.os_disk_size_gb
   }
 
-  dynamic storage_data_disk {
+  dynamic "storage_data_disk" {
     for_each = range(var.nb_data_disk)
     content {
       name              = "${var.vm_hostname}-datadisk-${count.index}-${storage_data_disk.value}"
@@ -193,7 +193,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
     }
   }
 
-  dynamic storage_data_disk {
+  dynamic "storage_data_disk" {
     for_each = var.extra_disks
     content {
       name              = "${var.vm_hostname}-extradisk-${count.index}-${storage_data_disk.value.name}"

--- a/os/outputs.tf
+++ b/os/outputs.tf
@@ -3,7 +3,7 @@ output "calculated_value_os_publisher" {
 }
 
 output "calculated_value_os_offer" {
-  value =element(split(",", lookup(var.standard_os, var.vm_os_simple, "")), 1)
+  value = element(split(",", lookup(var.standard_os, var.vm_os_simple, "")), 1)
 }
 
 output "calculated_value_os_sku" {

--- a/variables.tf
+++ b/variables.tf
@@ -246,3 +246,9 @@ variable "os_profile_secrets" {
   type        = list(map(string))
   default     = []
 }
+
+variable "os_disk_size_gb" {
+  description = "OS Disk size in GB."
+  type        = number
+  default     = 30
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-compute .
$ docker run --rm azure-compute /bin/bash -c "bundle install && rake full"
```

Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #172

Changes proposed in the pull request: make it possible to use larger OS disks (using datadisks is possible but honestly its a pain to get them up and running for quick turnaround)


