### PR TITLE
Bring support for marketplace images use with VMs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,15 @@ resource "azurerm_virtual_machine" "vm-linux" {
     version   = var.vm_os_id == "" ? var.vm_os_version : ""
   }
 
+  dynamic plan {
+    for_each = var.is_marketplace_image ? [1]: []
+    content {
+      name      = var.vm_os_offer
+      publisher = var.vm_os_publisher
+      product   = var.vm_os_sku
+    }
+  }
+
   storage_os_disk {
     name              = "osdisk-${var.vm_hostname}-${count.index}"
     create_option     = "FromImage"
@@ -172,6 +181,15 @@ resource "azurerm_virtual_machine" "vm-windows" {
     offer     = var.vm_os_id == "" ? coalesce(var.vm_os_offer, module.os.calculated_value_os_offer) : ""
     sku       = var.vm_os_id == "" ? coalesce(var.vm_os_sku, module.os.calculated_value_os_sku) : ""
     version   = var.vm_os_id == "" ? var.vm_os_version : ""
+  }
+
+  dynamic plan {
+    for_each = var.is_marketplace_image ? [1]: []
+    content {
+      name      = var.vm_os_offer
+      publisher = var.vm_os_publisher
+      product   = var.vm_os_sku
+    }
   }
 
   storage_os_disk {

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,13 @@ resource "azurerm_storage_account" "vm-sa" {
 }
 
 resource "azurerm_virtual_machine" "vm-linux" {
+  lifecycle {
+    precondition {
+      condition     = !var.is_marketplace_image || (var.vm_os_offer != null && var.vm_os_publisher != null && var.vm_os_sku != null)
+      error_message = "`var.vm_os_offer`, `vm_os_publisher` and `var.vm_os_sku` are required when `var.is_marketplace_image` is `true`."
+    }
+  }
+
   count                            = !contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer") && !var.is_windows_image ? var.nb_instances : 0
   name                             = "${var.vm_hostname}-vmLinux-${count.index}"
   resource_group_name              = data.azurerm_resource_group.vm.name

--- a/main.tf
+++ b/main.tf
@@ -70,8 +70,8 @@ resource "azurerm_virtual_machine" "vm-linux" {
     version   = var.vm_os_id == "" ? var.vm_os_version : ""
   }
 
-  dynamic plan {
-    for_each = var.is_marketplace_image ? [1]: []
+  dynamic "plan" {
+    for_each = var.is_marketplace_image ? [1] : []
     content {
       name      = var.vm_os_offer
       publisher = var.vm_os_publisher
@@ -190,8 +190,8 @@ resource "azurerm_virtual_machine" "vm-windows" {
     version   = var.vm_os_id == "" ? var.vm_os_version : ""
   }
 
-  dynamic plan {
-    for_each = var.is_marketplace_image ? [1]: []
+  dynamic "plan" {
+    for_each = var.is_marketplace_image ? [1] : []
     content {
       name      = var.vm_os_offer
       publisher = var.vm_os_publisher

--- a/variables.tf
+++ b/variables.tf
@@ -103,6 +103,12 @@ variable "is_windows_image" {
   default     = false
 }
 
+variable "is_marketplace_image" {
+  description = "Boolean flag to notify when the image comes from the marketplace."
+  type        = bool
+  default     = false
+}
+
 variable "vm_os_publisher" {
   description = "The name of the publisher of the image that you want to deploy. This is ignored when vm_os_id or vm_os_simple are provided."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,7 @@ variable "is_windows_image" {
 variable "is_marketplace_image" {
   description = "Boolean flag to notify when the image comes from the marketplace."
   type        = bool
+  nullable    = false
   default     = false
 }
 


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-compute .
$ docker run --rm azure-compute /bin/bash -c "bundle install && rake full"
```

Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:

Exchanged today with Alex from Azure support and we were unable to use marketplace image with this module, troubleshooting generated VM, what missed were the plan section of _azurerm_virtual_machine_

This PR allow users to use such type of images.



