### PR TITLE
Add option to use managed storage account for boot diagnostics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -140,16 +140,16 @@ resource "azurerm_virtual_machine" "vm-linux" {
 }
 
 resource "azurerm_virtual_machine" "vm-windows" {
-  count                         = (var.is_windows_image || contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer")) ? var.nb_instances : 0
-  name                          = "${var.vm_hostname}${count.index == 0 ? "" : "-${count.index+1}"}"
-  resource_group_name           = data.azurerm_resource_group.vm.name
-  location                      = coalesce(var.location, data.azurerm_resource_group.vm.location)
-  availability_set_id           = azurerm_availability_set.vm.id
-  vm_size                       = var.vm_size
-  network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
-  delete_os_disk_on_termination = var.delete_os_disk_on_termination
+  count                            = (var.is_windows_image || contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer")) ? var.nb_instances : 0
+  name                             = "${var.vm_hostname}${count.index == 0 ? "" : "-${count.index+1}"}"
+  resource_group_name              = data.azurerm_resource_group.vm.name
+  location                         = coalesce(var.location, data.azurerm_resource_group.vm.location)
+  availability_set_id              = azurerm_availability_set.vm.id
+  vm_size                          = var.vm_size
+  network_interface_ids            = [element(azurerm_network_interface.vm.*.id, count.index)]
+  delete_os_disk_on_termination    = var.delete_os_disk_on_termination
   delete_data_disks_on_termination = var.delete_data_disks_on_termination
-  license_type                  = var.license_type
+  license_type                     = var.license_type
 
   dynamic identity {
     for_each = length(var.identity_ids) == 0 && var.identity_type == "SystemAssigned" ? [var.identity_type] : []

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_storage_account" "vm-sa" {
 
 resource "azurerm_virtual_machine" "vm-linux" {
   count                            = ! contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer") && ! var.is_windows_image ? var.nb_instances : 0
-  name                             = "${var.vm_hostname}${count.index == 0 ? "-${count.index+1}" : ""}"
+  name                             = "${var.vm_hostname}${count.index == 0 ? "" : "-${count.index+1}"}"
   resource_group_name              = data.azurerm_resource_group.vm.name
   location                         = coalesce(var.location, data.azurerm_resource_group.vm.location)
   availability_set_id              = azurerm_availability_set.vm.id
@@ -64,7 +64,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   }
 
   storage_os_disk {
-    name              = "osdisk-${var.vm_hostname}${count.index == 0 ? "-${count.index+1}" : ""}"
+    name              = "osdisk-${var.vm_hostname}${count.index == 0 ? "" : "-${count.index+1}"}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     managed_disk_type = var.storage_account_type
@@ -73,7 +73,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   dynamic storage_data_disk {
     for_each = range(var.nb_data_disk)
     content {
-      name              = "${var.vm_hostname}-datadisk${count.index == 0 ? "-${count.index+1}" : ""}-${storage_data_disk.value}"
+      name              = "${var.vm_hostname}-datadisk${count.index == 0 ? "" : "-${count.index+1}"}-${storage_data_disk.value}"
       create_option     = "Empty"
       lun               = storage_data_disk.value
       disk_size_gb      = var.data_disk_size_gb
@@ -84,7 +84,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   dynamic storage_data_disk {
     for_each = var.extra_disks
     content {
-      name              = "${var.vm_hostname}-extradisk${count.index == 0 ? "-${count.index+1}" : ""}-${storage_data_disk.value.name}"
+      name              = "${var.vm_hostname}-extradisk${count.index == 0 ? "" : "-${count.index+1}"}-${storage_data_disk.value.name}"
       create_option     = "Empty"
       lun               = storage_data_disk.key + var.nb_data_disk
       disk_size_gb      = storage_data_disk.value.size
@@ -93,7 +93,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   }
 
   os_profile {
-    computer_name  = "${var.vm_hostname}${count.index == 0 ? "-${count.index+1}" : ""}"
+    computer_name  = "${var.vm_hostname}${count.index == 0 ? "" : "-${count.index+1}"}"
     admin_username = var.admin_username
     admin_password = var.admin_password
     custom_data    = var.custom_data
@@ -175,7 +175,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   }
 
   storage_os_disk {
-    name              = "${var.vm_hostname}-osdisk${count.index == 0 ? "-${count.index+1}" : ""}"
+    name              = "${var.vm_hostname}-osdisk${count.index == 0 ? "" : "-${count.index+1}"}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     managed_disk_type = var.storage_account_type
@@ -184,7 +184,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   dynamic storage_data_disk {
     for_each = range(var.nb_data_disk)
     content {
-      name              = "${var.vm_hostname}-datadisk${count.index == 0 ? "-${count.index+1}" : ""}-${storage_data_disk.value}"
+      name              = "${var.vm_hostname}-datadisk${count.index == 0 ? "" : "-${count.index+1}"}-${storage_data_disk.value}"
       create_option     = "Empty"
       lun               = storage_data_disk.value
       disk_size_gb      = var.data_disk_size_gb
@@ -195,7 +195,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   dynamic storage_data_disk {
     for_each = var.extra_disks
     content {
-      name              = "${var.vm_hostname}-extradisk${count.index == 0 ? "-${count.index+1}" : ""}-${storage_data_disk.value.name}"
+      name              = "${var.vm_hostname}-extradisk${count.index == 0 ? "" : "-${count.index+1}"}-${storage_data_disk.value.name}"
       create_option     = "Empty"
       lun               = storage_data_disk.key + var.nb_data_disk
       disk_size_gb      = storage_data_disk.value.size
@@ -204,7 +204,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   }
 
   os_profile {
-    computer_name  = "${var.vm_hostname}${count.index == 0 ? "-${count.index+1}" : ""}"
+    computer_name  = "${var.vm_hostname}${count.index == 0 ? "" : "-${count.index+1}"}"
     admin_username = var.admin_username
     admin_password = var.admin_password
   }
@@ -245,7 +245,7 @@ resource "azurerm_availability_set" "vm" {
 
 resource "azurerm_public_ip" "vm" {
   count               = var.nb_public_ip
-  name                = "${var.vm_hostname}-pip${count.index == 0 ? "-${count.index+1}" : ""}"
+  name                = "${var.vm_hostname}-pip${count.index == 0 ? "" : "-${count.index+1}"}"
   resource_group_name = data.azurerm_resource_group.vm.name
   location            = coalesce(var.location, data.azurerm_resource_group.vm.location)
   allocation_method   = var.allocation_method
@@ -288,13 +288,13 @@ resource "azurerm_network_security_rule" "vm" {
 
 resource "azurerm_network_interface" "vm" {
   count                         = var.nb_instances
-  name                          = "${var.vm_hostname}-nic${count.index == 0 ? "-${count.index+1}" : ""}"
+  name                          = "${var.vm_hostname}-nic${count.index == 0 ? "" : "-${count.index+1}"}"
   resource_group_name           = data.azurerm_resource_group.vm.name
   location                      = coalesce(var.location, data.azurerm_resource_group.vm.location)
   enable_accelerated_networking = var.enable_accelerated_networking
 
   ip_configuration {
-    name                          = "${var.vm_hostname}-ip${count.index == 0 ? "-${count.index+1}" : ""}"
+    name                          = "${var.vm_hostname}-ip${count.index == 0 ? "" : "-${count.index+1}"}"
     subnet_id                     = var.vnet_subnet_id
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, tolist([""])), count.index) : ""

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
     for_each = range(var.nb_data_disk)
     content {
       name              = "${var.vm_hostname}-datadisk${count.index == 0 ? "" : "-${count.index+1}"}-${storage_data_disk.value}"
-      create_option     = "Empty"
+      create_option     = var.data_disk_create_option
       lun               = storage_data_disk.value
       disk_size_gb      = var.data_disk_size_gb
       managed_disk_type = var.data_sa_type
@@ -85,7 +85,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
     for_each = var.extra_disks
     content {
       name              = "${var.vm_hostname}-extradisk${count.index == 0 ? "" : "-${count.index+1}"}-${storage_data_disk.value.name}"
-      create_option     = "Empty"
+      create_option     = var.data_disk_create_option
       lun               = storage_data_disk.key + var.nb_data_disk
       disk_size_gb      = storage_data_disk.value.size
       managed_disk_type = var.data_sa_type
@@ -212,6 +212,8 @@ resource "azurerm_virtual_machine" "vm-windows" {
   tags = var.tags
 
   os_profile_windows_config {
+    # can we add timezone and auto-updates in here ?
+    # or just manage this post-install ?
     provision_vm_agent = true
   }
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "random_id" "vm-sa" {
 }
 
 resource "azurerm_storage_account" "vm-sa" {
-  count                    = var.boot_diagnostics ? 1 : 0
+  count                    = var.boot_diagnostics && ! var.boot_diagnostics_sa_managed ? 1 : 0
   name                     = "bootdiag${lower(random_id.vm-sa.hex)}"
   resource_group_name      = data.azurerm_resource_group.vm.name
   location                 = coalesce(var.location, data.azurerm_resource_group.vm.location)

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_storage_account" "vm-sa" {
 
 resource "azurerm_virtual_machine" "vm-linux" {
   count                            = ! contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer") && ! var.is_windows_image ? var.nb_instances : 0
-  name                             = "${var.vm_hostname}-vmLinux-${count.index}"
+  name                             = "${var.vm_hostname}${count.index == 0 ? "-${count.index+1}" : ""}"
   resource_group_name              = data.azurerm_resource_group.vm.name
   location                         = coalesce(var.location, data.azurerm_resource_group.vm.location)
   availability_set_id              = azurerm_availability_set.vm.id
@@ -64,7 +64,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   }
 
   storage_os_disk {
-    name              = "osdisk-${var.vm_hostname}-${count.index}"
+    name              = "osdisk-${var.vm_hostname}${count.index == 0 ? "-${count.index+1}" : ""}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     managed_disk_type = var.storage_account_type
@@ -73,7 +73,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   dynamic storage_data_disk {
     for_each = range(var.nb_data_disk)
     content {
-      name              = "${var.vm_hostname}-datadisk-${count.index}-${storage_data_disk.value}"
+      name              = "${var.vm_hostname}-datadisk${count.index == 0 ? "-${count.index+1}" : ""}-${storage_data_disk.value}"
       create_option     = "Empty"
       lun               = storage_data_disk.value
       disk_size_gb      = var.data_disk_size_gb
@@ -84,7 +84,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   dynamic storage_data_disk {
     for_each = var.extra_disks
     content {
-      name              = "${var.vm_hostname}-extradisk-${count.index}-${storage_data_disk.value.name}"
+      name              = "${var.vm_hostname}-extradisk${count.index == 0 ? "-${count.index+1}" : ""}-${storage_data_disk.value.name}"
       create_option     = "Empty"
       lun               = storage_data_disk.key + var.nb_data_disk
       disk_size_gb      = storage_data_disk.value.size
@@ -93,7 +93,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   }
 
   os_profile {
-    computer_name  = "${var.vm_hostname}-${count.index}"
+    computer_name  = "${var.vm_hostname}${count.index == 0 ? "-${count.index+1}" : ""}"
     admin_username = var.admin_username
     admin_password = var.admin_password
     custom_data    = var.custom_data
@@ -141,13 +141,14 @@ resource "azurerm_virtual_machine" "vm-linux" {
 
 resource "azurerm_virtual_machine" "vm-windows" {
   count                         = (var.is_windows_image || contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer")) ? var.nb_instances : 0
-  name                          = "${var.vm_hostname}-vmWindows-${count.index}"
+  name                          = "${var.vm_hostname}${count.index == 0 ? "" : "-${count.index+1}"}"
   resource_group_name           = data.azurerm_resource_group.vm.name
   location                      = coalesce(var.location, data.azurerm_resource_group.vm.location)
   availability_set_id           = azurerm_availability_set.vm.id
   vm_size                       = var.vm_size
   network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
   delete_os_disk_on_termination = var.delete_os_disk_on_termination
+  delete_data_disks_on_termination = var.delete_data_disks_on_termination
   license_type                  = var.license_type
 
   dynamic identity {
@@ -174,7 +175,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   }
 
   storage_os_disk {
-    name              = "${var.vm_hostname}-osdisk-${count.index}"
+    name              = "${var.vm_hostname}-osdisk${count.index == 0 ? "-${count.index+1}" : ""}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     managed_disk_type = var.storage_account_type
@@ -183,7 +184,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   dynamic storage_data_disk {
     for_each = range(var.nb_data_disk)
     content {
-      name              = "${var.vm_hostname}-datadisk-${count.index}-${storage_data_disk.value}"
+      name              = "${var.vm_hostname}-datadisk${count.index == 0 ? "-${count.index+1}" : ""}-${storage_data_disk.value}"
       create_option     = "Empty"
       lun               = storage_data_disk.value
       disk_size_gb      = var.data_disk_size_gb
@@ -194,7 +195,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   dynamic storage_data_disk {
     for_each = var.extra_disks
     content {
-      name              = "${var.vm_hostname}-extradisk-${count.index}-${storage_data_disk.value.name}"
+      name              = "${var.vm_hostname}-extradisk${count.index == 0 ? "-${count.index+1}" : ""}-${storage_data_disk.value.name}"
       create_option     = "Empty"
       lun               = storage_data_disk.key + var.nb_data_disk
       disk_size_gb      = storage_data_disk.value.size
@@ -203,7 +204,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   }
 
   os_profile {
-    computer_name  = "${var.vm_hostname}-${count.index}"
+    computer_name  = "${var.vm_hostname}${count.index == 0 ? "-${count.index+1}" : ""}"
     admin_username = var.admin_username
     admin_password = var.admin_password
   }
@@ -244,7 +245,7 @@ resource "azurerm_availability_set" "vm" {
 
 resource "azurerm_public_ip" "vm" {
   count               = var.nb_public_ip
-  name                = "${var.vm_hostname}-pip-${count.index}"
+  name                = "${var.vm_hostname}-pip${count.index == 0 ? "-${count.index+1}" : ""}"
   resource_group_name = data.azurerm_resource_group.vm.name
   location            = coalesce(var.location, data.azurerm_resource_group.vm.location)
   allocation_method   = var.allocation_method
@@ -287,13 +288,13 @@ resource "azurerm_network_security_rule" "vm" {
 
 resource "azurerm_network_interface" "vm" {
   count                         = var.nb_instances
-  name                          = "${var.vm_hostname}-nic-${count.index}"
+  name                          = "${var.vm_hostname}-nic${count.index == 0 ? "-${count.index+1}" : ""}"
   resource_group_name           = data.azurerm_resource_group.vm.name
   location                      = coalesce(var.location, data.azurerm_resource_group.vm.location)
   enable_accelerated_networking = var.enable_accelerated_networking
 
   ip_configuration {
-    name                          = "${var.vm_hostname}-ip-${count.index}"
+    name                          = "${var.vm_hostname}-ip${count.index == 0 ? "-${count.index+1}" : ""}"
     subnet_id                     = var.vnet_subnet_id
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, tolist([""])), count.index) : ""

--- a/variables.tf
+++ b/variables.tf
@@ -184,6 +184,12 @@ variable "boot_diagnostics" {
   default     = false
 }
 
+variable "boot_diagnostics_sa_managed" {
+  type        = bool
+  description = "(Optional) Enable with managed storage account"
+  default     = false
+}
+
 variable "boot_diagnostics_sa_type" {
   description = "(Optional) Storage account type for boot diagnostics."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -172,6 +172,12 @@ variable "data_sa_type" {
   default     = "Standard_LRS"
 }
 
+variable "data_disk_create_option" {
+  description = "Data Disk Create Option."
+  type        = string
+  default     = "Empty"
+}
+
 variable "data_disk_size_gb" {
   description = "Storage data disk size size."
   type        = number


### PR DESCRIPTION
Add option to prevent the creation of a new storage account and thus use the managed storage account (apparently the recommended approach)

Defaulted to false for backwards comparability 

