### PR TITLE
Adjust the "plan" input to properly set the image name and product

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,8 +131,8 @@ resource "azurerm_virtual_machine" "vm_linux" {
     for_each = var.is_marketplace_image ? ["plan"] : []
 
     content {
-      name      = var.vm_os_offer
-      product   = var.vm_os_sku
+      name      = var.vm_os_sku
+      product   = var.vm_os_offer
       publisher = var.vm_os_publisher
     }
   }
@@ -245,8 +245,8 @@ resource "azurerm_virtual_machine" "vm_windows" {
     for_each = var.is_marketplace_image ? ["plan"] : []
 
     content {
-      name      = var.vm_os_offer
-      product   = var.vm_os_sku
+      name      = var.vm_os_sku
+      product   = var.vm_os_offer
       publisher = var.vm_os_publisher
     }
   }


### PR DESCRIPTION
## Describe your changes
When attempting to use a marketplace image, the terraform apply will currently fail with:

> │ Error: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ResourcePurchaseValidationFailed" Message="User failed validation to purchase resources. Error message: 'The offer with Offer ID '8-gen1' was not 
> found. Try one of these: 1- Make sure the offer name is written correctly. 2- If this offer was recently created, allow up to 30 minutes for it to be available for purchase. 3- The offer may have been removed from the marketplace. Look for similar offers from this p
> ublisher here: 'https://azuremarketplace.microsoft.com/en-us/marketplace/apps?page=1%26search=almalinux%208-gen1'. Publisher ID: 'almalinux', Offer ID: '8-gen1', Correlation ID 'XXX'.'"

Currently the "plan" input is constructed as:

```
  dynamic "plan" {
    for_each = var.is_marketplace_image ? ["plan"] : []

    content {
      name      = var.vm_os_offer
      product   = var.vm_os_sku
      publisher = var.vm_os_publisher
    }
  }
```

However, the name and product are being used incorrectly here. For example, consider image with URN **almalinux:almalinux:8-gen1:8.7.2022122801**. The 'az vm image list' and 'az vm image show' output for this image is (with some redactions):

```
[user@server]$ az vm image list --location eastus --publisher almalinux --offer almalinux --all
  {
    "offer": "almalinux",
    "publisher": "almalinux",
    "sku": "8-gen1",
    "urn": "almalinux:almalinux:8-gen1:8.7.2022122801",
    "version": "8.7.2022122801"
  },
```

```
[user@server]$ az vm image show -l eastus --urn almalinux:almalinux:8-gen1:8.7.2022122801
{
  "id": "/Subscriptions/f60cdb4a-1023-47c6-a3ff-6a3ef043f74d/Providers/Microsoft.Compute/Locations/eastus/Publishers/almalinux/ArtifactTypes/VMImage/Offers/almalinux/Skus/8-gen1/Versions/8.7.2022122801",
  "location": "eastus",
  "name": "8.7.2022122801",
  "plan": {
    "name": "8-gen1",
    "product": "almalinux",
    "publisher": "almalinux"
  },
}
```

So if I wish to schedule this image, the **correct** "plan" values are:

- Publisher: almalinux
- Product: almalinux
- Name: 8-gen1

However, the **incorrect** "plan" input currently being constructed by this module instead is:

- Publisher: almalinux
- Product: 8-gen1
- Name: almalinux

In short, the **product** and **name** are swapped. This PR is to correct this behavior.

## Issue number
No issue

## Checklist before requesting a review
- [X] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

