### PR TITLE
Added ability for using a azurerm_virtual_machine_data_disk_attachment resource for data disks, organizing resources by vm name, naming the storage account, and preventing use of network security group and availability set

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,34 @@
 locals {
   is_windows    = (var.is_windows_image || contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer")) || var.is_windows_image == true
   vm_extensions = { for p in setproduct(toset([for e in var.vm_extensions : e]), toset(range(var.nb_instances))) : "${p[0].name}-${p[1]}" => { index = p[1], value = p[0] } }
+
+  data_disk_list = flatten([
+    for host_number in range(var.nb_instances) : [
+      for data_disk_number in range(var.nb_data_disk_by_data_disk_attachment) : {
+        name        = var.group_by_vm_instance ? join("-", [var.vm_hostname, host_number, "datadisk", data_disk_number]) : join("-", [var.vm_hostname, "datadisk", host_number, data_disk_number])
+        host        = join("-", [var.vm_hostname, host_number])
+        host_number = host_number
+        disk_number = data_disk_number
+      }
+    ]
+  ])
+  data_disk_map         = { for obj in local.data_disk_list : obj.name => obj }
+  data_disk_map_linux   = { for obj in local.data_disk_list : obj.name => obj if !local.is_windows }
+  data_disk_map_windows = { for obj in local.data_disk_list : obj.name => obj if local.is_windows }
+
+  extra_disk_list = flatten([
+    for host_number in range(var.nb_instances) : [
+      for extra_disk in var.extra_disks_by_data_disk_attachment : {
+        name        = var.group_by_vm_instance ? join("-", [var.vm_hostname, host_number, "extradisk", extra_disk.name]) : join("-", [var.vm_hostname, "extradisk", host_number, extra_disk.name])
+        host        = join("-", [var.vm_hostname, host_number])
+        host_number = host_number
+        disk_number = index(var.extra_disks_by_data_disk_attachment, extra_disk)
+        disk_name   = extra_disk.name
+        disk_size   = extra_disk.size
+      }
+    ]
+  ])
+  extra_disk_map         = { for obj in local.extra_disk_list : obj.name => obj }
+  extra_disk_map_linux   = { for obj in local.extra_disk_list : obj.name => obj if !local.is_windows }
+  extra_disk_map_windows = { for obj in local.extra_disk_list : obj.name => obj if local.is_windows }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "delete_data_disks_on_termination" {
 
 variable "delete_os_disk_on_termination" {
   type        = bool
-  description = "Delete datadisk when machine is terminated."
+  description = "Delete OS disk when machine is terminated."
   default     = false
 }
 
@@ -178,7 +178,7 @@ variable "nb_public_ip" {
 }
 
 variable "network_security_group" {
-  description = "The network security group we'd like to bind with virtual machine. Set this variable will disable the creation of `azurerm_network_security_group` and `azurerm_network_security_rule` resources."
+  description = "The network security group we'd like to bind with virtual machine. Set this variable will disable the creation of `azurerm_network_security_group` and `azurerm_network_security_rule` resources.  To prevent the binding of a network security group, set `enable_network_security_group` to false."
   type = object({
     id = string
   })
@@ -366,9 +366,24 @@ variable "vm_size" {
 # it would be hard for us to keep the vm and public ip in the same zone once `var.nb_instances` doesn't equal to `var.nb_public_ip`
 # So, we decide that one module instance supports one zone only to avoid this dilemma.
 variable "zone" {
-  description = "(Optional) The Availability Zone which the Virtual Machine should be allocated in, only one zone would be accepted. If set then this module won't create `azurerm_availability_set` resource. Changing this forces a new resource to be created."
+  description = "(Optional) The Availability Zone which the Virtual Machine should be allocated in, only one zone would be accepted. If set then this module won't create `azurerm_availability_set` resource. Changing this forces a new resource to be created.  To prevent the usage of an availability set, set `enable_availability_set` to false."
   type        = string
   default     = null
+}
+
+variable "nb_data_disk_by_data_disk_attachment" {
+  description = "(Optional) Number of the data disks attached to each virtual machine using a azurerm_virtual_machine_data_disk_attachment resource.  Data Disks can be attached either directly by `nb_data_disk` and `extra_disks`, or using the azurerm_virtual_machine_data_disk_attachment resource by `nb_data_disk_by_data_disk_attachment` and `extra_disks_by_data_disk_attachment` - but the two cannot be used together."
+  type        = number
+  default     = 0
+}
+
+variable "extra_disks_by_data_disk_attachment" {
+  description = "(Optional) List of extra data disks attached to each virtual machine using a azurerm_virtual_machine_data_disk_attachment resource.  Data Disks can be attached either directly by `nb_data_disk` and `extra_disks`, or using the azurerm_virtual_machine_data_disk_attachment resource by `nb_data_disk_by_data_disk_attachment` and `extra_disks_by_data_disk_attachment` - but the two cannot be used together."
+  type = list(object({
+    name = string
+    size = number
+  }))
+  default = []
 }
 
 variable "storage_account_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -370,3 +370,28 @@ variable "zone" {
   type        = string
   default     = null
 }
+
+variable "storage_account_name" {
+  description = "(Optional) The name of a Storage Account to create.  Leave empty to skip creating the storage account.  IMPORTANT: Must be lower case letters and numbers ONLY!"
+  type        = string
+  default     = null
+}
+
+variable "enable_availability_set" {
+  type        = bool
+  description = "(Optional) Enable or Disable availability set.  Default is true (enabled)."
+  default     = true
+}
+
+variable "enable_network_security_group" {
+  type        = bool
+  description = "(Optional) Enable or Disable network security group.  Default is true (enabled)."
+  default     = true
+}
+
+variable "group_by_vm_instance" {
+  type        = bool
+  description = "(Optional) Enable or Disable grouping by vm instances.  Default is to group by type."
+  default     = false
+}
+


### PR DESCRIPTION
## Describe your changes
* Added ability to use the `azurerm_virtual_machine_data_disk_attachment` resource for adding the data disks and extra disks.  This allows the VM to be destroyed and recreated through an update to the terraform configuration while the data disks remain and get reattached.
* Added the variable `storage_account_name` to name the storage account that is created.
* Added the variable `enable_availability_set` to prevent the creation or usage of an availability set when set false.
* Added the variable `enable_network_security_group` to prevent the creation or usage of a network security group when set false.
* Added the variable `group_by_vm_instance` to group all resources by VM instance name first, instead of by resource type.  Names will be in the format of <vm name>-<vm index>-<resource name>...

## Checklist before requesting a review
- [X] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [X] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine  - This cannot pass, as the following errors occur, even in the master branch:
╷
│ Error: Argument or block definition required
│
│   on unit-fixture/locals.tf line 1:
│    1: ../locals.tf
│
│ An argument or block definition is required here.
╵

╷
│ Error: Argument or block definition required
│
│   on unit-fixture/variables.tf line 1:
│    1: ../variables.tf
│
│ An argument or block definition is required here.
╵

make: *** [tfmod-scaffold/GNUmakefile:17: tffmt] Error 2


