### PR TITLE
Pin the iterator variable to avoid concurrent test error

### DIFF
--- a/test/unit/terraform_compute_test.go
+++ b/test/unit/terraform_compute_test.go
@@ -91,9 +91,10 @@ func Test_ExtensionVmIdMap(t *testing.T) {
 		true,
 	}
 	for _, w := range isWindowsImages {
-		t.Run(strconv.FormatBool(w), func(t *testing.T) {
+		isWindows := w
+		t.Run(strconv.FormatBool(isWindows), func(t *testing.T) {
 			vars := map[string]interface{}{
-				"is_windows_image": w,
+				"is_windows_image": isWindows,
 				"nb_instances":     2,
 			}
 			test_helper.RunE2ETest(t, "../../", "unit-fixture", terraform.Options{
@@ -108,7 +109,7 @@ func Test_ExtensionVmIdMap(t *testing.T) {
 					output := m["outputs"].(map[string]interface{})
 					vmId := output["virtual_machine_id"].(string)
 					prefix := "linux-%s"
-					if w {
+					if isWindows {
 						prefix = "windows-%s"
 					}
 					index := strings.Split(k, "-")[1]


### PR DESCRIPTION
## Describe your changes

We have a classic `foreach` error in our go test code, it would cause randomly error when we try to execute tests concurrently, this pull request capture the iterator variable into a local variable to avoid such error.

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

