### PR TITLE
Improve separate data disk resource logic

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -61,26 +61,26 @@ locals {
 }
 
 module "ubuntuservers" {
-  source                           = "../.."
-  vm_hostname                      = "${random_id.ip_dns.hex}-u"
-  resource_group_name              = azurerm_resource_group.test.name
-  location                         = var.location_alt
-  admin_username                   = var.admin_username
-  admin_password                   = local.admin_password
-  vm_os_simple                     = var.vm_os_simple_1
-  public_ip_dns                    = ["ubuntusimplevmips-${random_id.ip_dns.hex}"]
-  vnet_subnet_id                   = azurerm_subnet.subnet[0].id
-  allocation_method                = "Static"
-  public_ip_sku                    = "Standard"
-  enable_accelerated_networking    = true
-  delete_data_disks_on_termination = true
-  delete_os_disk_on_termination    = true
-  ssh_key                          = fileexists("~/.ssh/id_rsa.pub") ? "~/.ssh/id_rsa.pub" : ""
-  extra_ssh_keys                   = local.ubuntu_ssh_keys
-  vm_size                          = "Standard_DS2_V2"
-  nb_data_disk                     = 2
-  identity_type                    = "UserAssigned"
-  identity_ids                     = [azurerm_user_assigned_identity.vm.id]
+  source                        = "../.."
+  vm_hostname                   = "${random_id.ip_dns.hex}-u"
+  resource_group_name           = azurerm_resource_group.test.name
+  location                      = var.location_alt
+  admin_username                = var.admin_username
+  admin_password                = local.admin_password
+  vm_os_simple                  = var.vm_os_simple_1
+  public_ip_dns                 = ["ubuntusimplevmips-${random_id.ip_dns.hex}"]
+  vnet_subnet_id                = azurerm_subnet.subnet[0].id
+  allocation_method             = "Static"
+  public_ip_sku                 = "Standard"
+  enable_accelerated_networking = true
+  delete_os_disk_on_termination = true
+  ssh_key                       = fileexists("~/.ssh/id_rsa.pub") ? "~/.ssh/id_rsa.pub" : ""
+  extra_ssh_keys                = local.ubuntu_ssh_keys
+  vm_size                       = "Standard_DS2_V2"
+  nb_data_disk                  = 2
+  nested_data_disks             = false
+  identity_type                 = "UserAssigned"
+  identity_ids                  = [azurerm_user_assigned_identity.vm.id]
   os_profile_secrets = [
     {
       source_vault_id = azurerm_key_vault.test.id
@@ -229,6 +229,8 @@ module "windowsservers" {
   license_type        = var.license_type
   identity_type       = "UserAssigned"
   identity_ids        = [azurerm_user_assigned_identity.vm.id]
+  nb_data_disk        = 1
+  nested_data_disks   = false
   os_profile_secrets = [
     {
       source_vault_id   = azurerm_key_vault.test.id

--- a/locals.tf
+++ b/locals.tf
@@ -24,9 +24,11 @@ locals {
       }
     ]
   ])
-  extra_disk_map         = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks }
-  extra_disk_map_linux   = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks && !local.is_windows }
-  extra_disk_map_windows = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks && local.is_windows }
-  is_windows             = (var.is_windows_image || contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer")) || var.is_windows_image == true
-  vm_extensions          = { for p in setproduct(toset([for e in var.vm_extensions : e]), toset(range(var.nb_instances))) : "${p[0].name}-${p[1]}" => { index = p[1], value = p[0] } }
+  extra_disk_map              = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks }
+  extra_disk_map_linux        = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks && !local.is_windows }
+  extra_disk_map_windows      = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks && local.is_windows }
+  is_windows                  = (var.is_windows_image || contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer")) || var.is_windows_image == true
+  nested_data_disk_list       = var.nested_data_disks ? range(var.nb_data_disk) : []
+  nested_extra_data_disk_list = var.nested_data_disks ? var.extra_disks : []
+  vm_extensions               = { for p in setproduct(toset([for e in var.vm_extensions : e]), toset(range(var.nb_instances))) : "${p[0].name}-${p[1]}" => { index = p[1], value = p[0] } }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -2,19 +2,21 @@ locals {
   data_disk_list = flatten([
     for host_number in range(var.nb_instances) : [
       for data_disk_number in range(var.nb_data_disk) : {
-        name        = join("-", ["datadisk", host_number, data_disk_number])
+        key         = join("-", ["datadisk", host_number, data_disk_number])
+        name        = join("-", [var.vm_hostname, "datadisk", host_number, data_disk_number])
         host_number = host_number
         disk_number = data_disk_number
       }
     ]
   ])
-  data_disk_map         = { for obj in local.data_disk_list : obj.name => obj if !var.nested_data_disks }
-  data_disk_map_linux   = { for obj in local.data_disk_list : obj.name => obj if !var.nested_data_disks && !local.is_windows }
-  data_disk_map_windows = { for obj in local.data_disk_list : obj.name => obj if !var.nested_data_disks && local.is_windows }
+  data_disk_map         = { for obj in local.data_disk_list : obj.key => obj if !var.nested_data_disks }
+  data_disk_map_linux   = { for obj in local.data_disk_list : obj.key => obj if !var.nested_data_disks && !local.is_windows }
+  data_disk_map_windows = { for obj in local.data_disk_list : obj.key => obj if !var.nested_data_disks && local.is_windows }
   extra_disk_list = flatten([
     for host_number in range(var.nb_instances) : [
       for extra_disk in var.extra_disks : {
-        name        = join("-", ["extradisk", host_number, extra_disk.name])
+        key         = join("-", ["extradisk", host_number, extra_disk.name])
+        name        = join("-", [var.vm_hostname, "extradisk", host_number, extra_disk.name])
         host_number = host_number
         disk_number = index(var.extra_disks, extra_disk)
         disk_name   = extra_disk.name
@@ -22,9 +24,9 @@ locals {
       }
     ]
   ])
-  extra_disk_map              = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks }
-  extra_disk_map_linux        = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks && !local.is_windows }
-  extra_disk_map_windows      = { for obj in local.extra_disk_list : obj.name => obj if !var.nested_data_disks && local.is_windows }
+  extra_disk_map              = { for obj in local.extra_disk_list : obj.key => obj if !var.nested_data_disks }
+  extra_disk_map_linux        = { for obj in local.extra_disk_list : obj.key => obj if !var.nested_data_disks && !local.is_windows }
+  extra_disk_map_windows      = { for obj in local.extra_disk_list : obj.key => obj if !var.nested_data_disks && local.is_windows }
   is_windows                  = (var.is_windows_image || contains(tolist([var.vm_os_simple, var.vm_os_offer]), "WindowsServer")) || var.is_windows_image == true
   nested_data_disk_list       = var.nested_data_disks ? range(var.nb_data_disk) : []
   nested_extra_data_disk_list = var.nested_data_disks ? var.extra_disks : []

--- a/locals.tf
+++ b/locals.tf
@@ -2,8 +2,7 @@ locals {
   data_disk_list = flatten([
     for host_number in range(var.nb_instances) : [
       for data_disk_number in range(var.nb_data_disk) : {
-        name        = join("-", [var.vm_hostname, "datadisk", host_number, data_disk_number])
-        host        = join("-", [var.vm_hostname, host_number])
+        name        = join("-", ["datadisk", host_number, data_disk_number])
         host_number = host_number
         disk_number = data_disk_number
       }
@@ -15,8 +14,7 @@ locals {
   extra_disk_list = flatten([
     for host_number in range(var.nb_instances) : [
       for extra_disk in var.extra_disks : {
-        name        = join("-", [var.vm_hostname, "extradisk", host_number, extra_disk.name])
-        host        = join("-", [var.vm_hostname, host_number])
+        name        = join("-", ["extradisk", host_number, extra_disk.name])
         host_number = host_number
         disk_number = index(var.extra_disks, extra_disk)
         disk_name   = extra_disk.name

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "azurerm_virtual_machine" "vm_linux" {
     }
   }
   dynamic "storage_data_disk" {
-    for_each = var.nested_data_disks ? range(var.nb_data_disk) : []
+    for_each = local.nested_data_disk_list
 
     content {
       create_option     = "Empty"
@@ -146,7 +146,7 @@ resource "azurerm_virtual_machine" "vm_linux" {
     }
   }
   dynamic "storage_data_disk" {
-    for_each = var.nested_data_disks ? var.extra_disks : []
+    for_each = local.nested_extra_data_disk_list
 
     content {
       create_option     = "Empty"
@@ -168,6 +168,10 @@ resource "azurerm_virtual_machine" "vm_linux" {
     precondition {
       condition     = !var.is_marketplace_image || (var.vm_os_offer != null && var.vm_os_publisher != null && var.vm_os_sku != null)
       error_message = "`var.vm_os_offer`, `vm_os_publisher` and `var.vm_os_sku` are required when `var.is_marketplace_image` is `true`."
+    }
+    precondition {
+      condition     = !var.nested_data_disks || var.delete_data_disks_on_termination != true
+      error_message = "`var.nested_data_disks` must be `true` when `var.delete_data_disks_on_termination` is `true`, because when you declare data disks via separate managed disk resource, you might want to preserve the data while recreating the vm instance."
     }
   }
 }
@@ -247,7 +251,7 @@ resource "azurerm_virtual_machine" "vm_windows" {
     }
   }
   dynamic "storage_data_disk" {
-    for_each = var.nested_data_disks ? range(var.nb_data_disk) : []
+    for_each = local.nested_data_disk_list
 
     content {
       create_option     = "Empty"
@@ -258,7 +262,7 @@ resource "azurerm_virtual_machine" "vm_windows" {
     }
   }
   dynamic "storage_data_disk" {
-    for_each = var.nested_data_disks ? var.extra_disks : []
+    for_each = local.nested_extra_data_disk_list
 
     content {
       create_option     = "Empty"
@@ -280,6 +284,10 @@ resource "azurerm_virtual_machine" "vm_windows" {
     precondition {
       condition     = !var.is_marketplace_image || (var.vm_os_offer != null && var.vm_os_publisher != null && var.vm_os_sku != null)
       error_message = "`var.vm_os_offer`, `vm_os_publisher` and `var.vm_os_sku` are required when `var.is_marketplace_image` is `true`."
+    }
+    precondition {
+      condition     = !var.nested_data_disks || var.delete_data_disks_on_termination != true
+      error_message = "`var.nested_data_disks` must be `true` when `var.delete_data_disks_on_termination` is `true`, because when you declare data disks via separate managed disk resource, you might want to preserve the data while recreating the vm instance."
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -297,7 +297,7 @@ resource "azurerm_managed_disk" "vm_data_disk" {
 
   create_option          = "Empty"
   location               = local.location
-  name                   = each.key
+  name                   = each.value.name
   resource_group_name    = var.resource_group_name
   storage_account_type   = var.data_sa_type
   disk_encryption_set_id = var.managed_data_disk_encryption_set_id
@@ -328,7 +328,7 @@ resource "azurerm_managed_disk" "vm_extra_disk" {
 
   create_option          = "Empty"
   location               = local.location
-  name                   = each.key
+  name                   = each.value.name
   resource_group_name    = var.resource_group_name
   storage_account_type   = var.data_sa_type
   disk_encryption_set_id = var.managed_data_disk_encryption_set_id

--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ resource "azurerm_virtual_machine" "vm_linux" {
       error_message = "`var.vm_os_offer`, `vm_os_publisher` and `var.vm_os_sku` are required when `var.is_marketplace_image` is `true`."
     }
     precondition {
-      condition     = !var.nested_data_disks || var.delete_data_disks_on_termination != true
+      condition     = var.nested_data_disks || var.delete_data_disks_on_termination != true
       error_message = "`var.nested_data_disks` must be `true` when `var.delete_data_disks_on_termination` is `true`, because when you declare data disks via separate managed disk resource, you might want to preserve the data while recreating the vm instance."
     }
   }
@@ -286,7 +286,7 @@ resource "azurerm_virtual_machine" "vm_windows" {
       error_message = "`var.vm_os_offer`, `vm_os_publisher` and `var.vm_os_sku` are required when `var.is_marketplace_image` is `true`."
     }
     precondition {
-      condition     = !var.nested_data_disks || var.delete_data_disks_on_termination != true
+      condition     = var.nested_data_disks || var.delete_data_disks_on_termination != true
       error_message = "`var.nested_data_disks` must be `true` when `var.delete_data_disks_on_termination` is `true`, because when you declare data disks via separate managed disk resource, you might want to preserve the data while recreating the vm instance."
     }
   }

--- a/test/unit/terraform_compute_test.go
+++ b/test/unit/terraform_compute_test.go
@@ -119,3 +119,102 @@ func Test_ExtensionVmIdMap(t *testing.T) {
 		})
 	}
 }
+
+func Test_DefaultOrTrueNestedDataDisksShouldNotCreateAttachmentResource(t *testing.T) {
+	test_helper.RunE2ETest(t, "../../", "unit-fixture", terraform.Options{
+		Vars: map[string]interface{}{
+			"nested_data_disks": true,
+			"nb_instances":      2,
+			"nb_data_disk":      2,
+			"extra_disks": `[
+	{ 
+		name = "lun0"
+		size = 30
+	}
+]`,
+		},
+	}, func(t *testing.T, output test_helper.TerraformOutput) {
+		dataList := output["data_disk_list"].([]any)
+		require.NotEmpty(t, dataList)
+		nestedDataDiskList := output["nested_data_disk_list"].([]any)
+		require.Equal(t, 2, len(nestedDataDiskList))
+		extraDataList := output["extra_data_disk_list"].([]any)
+		require.NotEmpty(t, extraDataList)
+		nestedExtraDataList := output["nested_extra_data_disk_list"].([]any)
+		require.NotEmpty(t, nestedExtraDataList)
+		dataDisks := output["data_disk_map"].(map[string]any)
+		require.Empty(t, dataDisks)
+		extraDataDisks := output["extra_disk_map"].(map[string]any)
+		require.Empty(t, extraDataDisks)
+	})
+}
+
+func Test_FalseNestedDataDisksShouldCreateAttachmentResource(t *testing.T) {
+	test_helper.RunE2ETest(t, "../../", "unit-fixture", terraform.Options{
+		Vars: map[string]interface{}{
+			"nested_data_disks": false,
+			"nb_instances":      2,
+			"nb_data_disk":      2,
+			"extra_disks": `[
+	{ 
+		name = "lun0"
+		size = 30
+	}
+]`,
+		},
+	}, func(t *testing.T, output test_helper.TerraformOutput) {
+		dataList := output["data_disk_list"].([]any)
+		require.NotEmpty(t, dataList)
+		nestedDataDiskList := output["nested_data_disk_list"].([]any)
+		require.Empty(t, nestedDataDiskList)
+		extraDataList := output["extra_data_disk_list"].([]any)
+		require.NotEmpty(t, extraDataList)
+		nestedExtraDataList := output["nested_extra_data_disk_list"].([]any)
+		require.Empty(t, nestedExtraDataList)
+		dataDisks := output["data_disk_map"].(map[string]any)
+		require.Equal(t, 4, len(dataDisks))
+		extraDataDisks := output["extra_disk_map"].(map[string]any)
+		require.Equal(t, 2, len(extraDataDisks))
+	})
+}
+
+func Test_DataDisksAttachmentShouldMatchOs(t *testing.T) {
+	isWindows := []bool{
+		false, true,
+	}
+	for _, w := range isWindows {
+		isLinux := !w
+		t.Run(strconv.FormatBool(isLinux), func(t *testing.T) {
+			test_helper.RunE2ETest(t, "../../", "unit-fixture", terraform.Options{
+				Vars: map[string]interface{}{
+					"is_windows_image":  !isLinux,
+					"nested_data_disks": false,
+					"nb_instances":      2,
+					"nb_data_disk":      2,
+					"extra_disks": `[
+	{ 
+		name = "lun0"
+		size = 30
+	}
+]`,
+				},
+			}, func(t *testing.T, output test_helper.TerraformOutput) {
+				dataDiskMapLinux := output["data_disk_map_linux"].(map[string]any)
+				dataDiskMapWindows := output["data_disk_map_windows"].(map[string]any)
+				extraDiskMapLinux := output["extra_disk_map_linux"].(map[string]any)
+				extraDiskMapWindows := output["extra_disk_map_windows"].(map[string]any)
+				if isLinux {
+					require.Empty(t, dataDiskMapWindows)
+					require.Empty(t, extraDiskMapWindows)
+					require.NotEmpty(t, dataDiskMapLinux)
+					require.NotEmpty(t, extraDiskMapLinux)
+				} else {
+					require.NotEmpty(t, dataDiskMapWindows)
+					require.NotEmpty(t, extraDiskMapWindows)
+					require.Empty(t, dataDiskMapLinux)
+					require.Empty(t, extraDiskMapLinux)
+				}
+			})
+		})
+	}
+}

--- a/unit-fixture/outputs.tf
+++ b/unit-fixture/outputs.tf
@@ -1,9 +1,49 @@
-output "vm_extensions" {
-  value     = local.vm_extensions
-  sensitive = true
+output "data_disk_list" {
+  value = local.data_disk_list
+}
+
+output "data_disk_map" {
+  value = local.data_disk_map
+}
+
+output "data_disk_map_linux" {
+  value = local.data_disk_map_linux
+}
+
+output "data_disk_map_windows" {
+  value = local.data_disk_map_windows
+}
+
+output "extra_data_disk_list" {
+  value = local.extra_disk_list
+}
+
+output "extra_disk_map" {
+  value = local.extra_disk_map
+}
+
+output "extra_disk_map_linux" {
+  value = local.extra_disk_map_linux
+}
+
+output "extra_disk_map_windows" {
+  value = local.extra_disk_map_windows
 }
 
 output "generated_extensions" {
   value     = data.null_data_source.extensions
+  sensitive = true
+}
+
+output "nested_data_disk_list" {
+  value = local.nested_data_disk_list
+}
+
+output "nested_extra_data_disk_list" {
+  value = local.nested_extra_data_disk_list
+}
+
+output "vm_extensions" {
+  value     = local.vm_extensions
   sensitive = true
 }


### PR DESCRIPTION
## Describe your changes

This pull request added unit tests and `precondition` check logic for separate data disk logic.

The pr also change data disk list generation logic in `locals.tf`, we've removed `var.vm_hostname` from map's key so we can use this map with `for_each` when `var.vm_hostname` is generated from another resource, like random.

This pr is an amendment to #227.

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

