### PR TITLE
Fix broken ip_configuration when azurerm_public_ip is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fix broken example [\#245](https://github.com/Azure/terraform-azurerm-compute/pull/245) ([lonegunmanb](https://github.com/lonegunmanb))
 
+**Pull requests:**
+
+* Fix broken ip_configuration when `azurerm_public_ip` is null
+
 ## [5.2.0](https://github.com/Azure/terraform-azurerm-compute/tree/5.2.0) (2023-02-28)
 
 **Merged pull requests:**

--- a/main.tf
+++ b/main.tf
@@ -445,7 +445,7 @@ resource "azurerm_network_interface" "vm" {
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id = length(azurerm_public_ip.vm[*].id) > 0 ? element(concat(azurerm_public_ip.vm[*].id, tolist([
       ""
-    ])), count.index) : ""
+    ])), count.index) : null
     subnet_id = var.vnet_subnet_id
   }
 }


### PR DESCRIPTION
## Problem
The error below appear when `length(azurerm_public_ip.vm[*].id) = 0`
```
╷
│ Error: parsing Azure ID: parse "": empty url
│ 
│   with module.vms["aiola"].azurerm_network_interface.vm[0],
│   on .terraform/modules/vms/main.tf line 446, in resource "azurerm_network_interface" "vm":
│  446:     public_ip_address_id = length(azurerm_public_ip.vm[*].id) > 0 ? element(concat(azurerm_public_ip.vm[*].id, tolist([
│  447:       ""
│  448:     ])), count.index) : ""
│ 
╵

```

## Describe your changes

* Change `azurerm_public_ip` to null instead of empty string.

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine
